### PR TITLE
Expand content width to 95%

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 This repository contains a simple monthly home budgeting app.
 
 ## Usage
-Open `index.html` in a browser to track your income and expenses for each month.
+Open `index.html` in a browser to track your income and expenses for each month. The app now uses 95% of your screen width to provide a wider workspace.
 
 ### Month Controls
 You can now add a new budget month or switch between months using the inline controls in the header.

--- a/styles.css
+++ b/styles.css
@@ -29,7 +29,7 @@
       .toolbar button{cursor:pointer}
       .inline-field{display:inline-flex;align-items:center;gap:6px}
 
-    main{padding:18px;max-width:1400px;margin:0 auto;}
+    main{padding:18px;width:95%;margin:0 auto;}
     .tabs{display:flex;gap:8px;margin-bottom:12px}
     .tab{border:1px solid var(--border);background:var(--card);padding:8px 12px;border-radius:10px;cursor:pointer}
     .tab[aria-selected="true"]{background:#111827;color:#fff;border-color:#111827}


### PR DESCRIPTION
## Summary
- widen main content area to 95% of the screen for better use of space
- document wider layout in readme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa0a1f1ca8832f84e012155dc7a0c7