### PR TITLE
Remove overview section and reposition categories

### DIFF
--- a/app.js
+++ b/app.js
@@ -261,12 +261,9 @@
       learnAdd: document.getElementById('learn-add'),
       learnList: document.getElementById('learn-list'),
 
-      // Charts
-      barCategories: document.getElementById('bar-categories'),
-      donutActual: document.getElementById('donut-actual'),
-      donutBudget: document.getElementById('donut-budget'),
-      barPerCat: document.getElementById('bar-percat')
-    };
+        // Charts
+        barPerCat: document.getElementById('bar-percat')
+      };
 
     let currentMonthKey = Utils.monthKey();
     let editingIncomeId = null;
@@ -384,27 +381,19 @@
       refreshKPIs();
     }
 
-    function refreshKPIs(){
-      const month = Store.getMonth(currentMonthKey);
-      const t = Model.totals(month);
-      els.totalIncome.textContent = Utils.fmt(t.income);
-      els.leftoverActual.textContent = Utils.fmt(t.leftoverActual);
-      els.leftoverPill.textContent = `Left Over ${Utils.fmt(t.leftoverActual)}`;
+      function refreshKPIs(){
+        const month = Store.getMonth(currentMonthKey);
+        const t = Model.totals(month);
+        els.totalIncome.textContent = Utils.fmt(t.income);
+        els.leftoverActual.textContent = Utils.fmt(t.leftoverActual);
+        els.leftoverPill.textContent = `Left Over ${Utils.fmt(t.leftoverActual)}`;
 
-      // Charts
-      const groups = Object.keys(t.groups).sort();
-      const budgetSeries = groups.map(g=>t.groups[g].budget);
-      const actualSeries = groups.map(g=>t.groups[g].actual);
-      Charts.bar(els.barCategories, groups, [budgetSeries, actualSeries]);
-      Charts.donut(els.donutBudget, Object.fromEntries(groups.map(g=>[g,t.groups[g].budget])));
-      Charts.donut(els.donutActual, Object.fromEntries(groups.map(g=>[g,t.groups[g].actual])));
-
-      // Per-category bar
-      const cats = Object.keys(month.categories).sort();
-      const b2 = cats.map(c=>month.categories[c].budget||0);
-      const a2 = cats.map(c=>t.actualPerCat[c]||0);
-      Charts.bar(els.barPerCat, cats, [b2,a2]);
-    }
+        // Per-category bar
+        const cats = Object.keys(month.categories).sort();
+        const b2 = cats.map(c=>month.categories[c].budget||0);
+        const a2 = cats.map(c=>t.actualPerCat[c]||0);
+        Charts.bar(els.barPerCat, cats, [b2,a2]);
+      }
 
     // ---- Event wiring
     els.addIncome.onclick = ()=>{

--- a/index.html
+++ b/index.html
@@ -40,82 +40,66 @@
       <button class="tab" role="tab" id="tab-learning" aria-selected="false">Prediction Map</button>
     </div>
 
-    <section id="panel-budget" role="tabpanel">
-      <div class="grid">
-        <div class="card">
-          <h2>Money In</h2>
-          <div class="content">
-            <div class="row">
-              <input id="income-name" placeholder="Income name e.g. Salary, Interest"/>
-              <input id="income-amount" type="number" step="0.01" placeholder="Amount"/>
-              <button class="primary" id="add-income">Add Income</button>
-            </div>
-            <div class="list" id="income-list"></div>
-            <div class="kpi" style="margin-top:10px">
-              <div><span>Total Income</span><strong id="total-income">£0.00</strong></div>
-              <div><span>Income − Actual Expenses</span><strong id="leftover-actual">£0.00</strong></div>
-            </div>
-          </div>
-        </div>
-
-        <div class="card">
-          <h2>Overview</h2>
-          <div class="content charts">
-            <canvas id="bar-categories" height="360"></canvas>
-            <div class="two-col">
-              <div>
-                <h3 style="margin:0 0 8px 0">Actual Split</h3>
-                <canvas id="donut-actual" height="360"></canvas>
+      <section id="panel-budget" role="tabpanel">
+        <div class="grid">
+          <div class="card">
+            <h2>Money In</h2>
+            <div class="content">
+              <div class="row">
+                <input id="income-name" placeholder="Income name e.g. Salary, Interest"/>
+                <input id="income-amount" type="number" step="0.01" placeholder="Amount"/>
+                <button class="primary" id="add-income">Add Income</button>
               </div>
-              <div>
-                <h3 style="margin:0 0 8px 0">Budget Split</h3>
-                <canvas id="donut-budget" height="360"></canvas>
+              <div class="list" id="income-list"></div>
+              <div class="kpi" style="margin-top:10px">
+                <div><span>Total Income</span><strong id="total-income">£0.00</strong></div>
+                <div><span>Income − Actual Expenses</span><strong id="leftover-actual">£0.00</strong></div>
               </div>
             </div>
           </div>
-        </div>
-      </div>
 
-      <div class="card" style="margin-top:18px">
-        <h2>Money Out – Categories</h2>
-        <div class="content">
-          <div class="row" style="margin-bottom:10px">
-            <input id="cat-name" placeholder="Category name (e.g. Groceries)"/>
-            <input id="cat-group" placeholder="Group (e.g. Food)"/>
-            <input id="cat-budget" type="number" step="0.01" placeholder="Budget"/>
-            <button class="primary" id="add-category">Add/Update Category</button>
-            <button class="ghost" id="reset-template" title="Reset current month categories to default template">Template</button>
-            <button class="ghost" id="collapse-all" title="Collapse all groups">Collapse All</button>
-            <button class="ghost" id="expand-all" title="Expand all groups">Expand All</button>
+          <div class="card">
+            <h2>Money Out – Categories</h2>
+            <div class="content">
+              <div class="row" style="margin-bottom:10px">
+                <input id="cat-name" placeholder="Category name (e.g. Groceries)"/>
+                <input id="cat-group" placeholder="Group (e.g. Food)"/>
+                <input id="cat-budget" type="number" step="0.01" placeholder="Budget"/>
+                <button class="primary" id="add-category">Add/Update Category</button>
+                <button class="ghost" id="reset-template" title="Reset current month categories to default template">Template</button>
+                <button class="ghost" id="collapse-all" title="Collapse all groups">Collapse All</button>
+                <button class="ghost" id="expand-all" title="Expand all groups">Expand All</button>
+              </div>
+
+              <table class="table" id="category-table">
+                <thead>
+                  <tr>
+                    <th>Group</th>
+                    <th>Category</th>
+                    <th class="right">Budget</th>
+                    <th class="right">Actual</th>
+                    <th class="right">Difference</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+                <tfoot>
+                  <tr>
+                    <td><strong>Totals</strong></td>
+                    <td></td>
+                    <td class="right" id="tot-bud">£0.00</td>
+                    <td class="right" id="tot-act">£0.00</td>
+                    <td class="right" id="tot-diff">£0.00</td>
+                    <td></td>
+                  </tr>
+                </tfoot>
+              </table>
+              <div class="footer-note">Tip: Click a row to edit. Difference = Budget − Actual.</div>
+            </div>
           </div>
 
-          <table class="table" id="category-table">
-            <thead>
-              <tr>
-                <th>Group</th>
-                <th>Category</th>
-                <th class="right">Budget</th>
-                <th class="right">Actual</th>
-                <th class="right">Difference</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-            <tfoot>
-              <tr>
-                <td><strong>Totals</strong></td>
-                <td></td>
-                <td class="right" id="tot-bud">£0.00</td>
-                <td class="right" id="tot-act">£0.00</td>
-                <td class="right" id="tot-diff">£0.00</td>
-                <td></td>
-              </tr>
-            </tfoot>
-          </table>
-          <div class="footer-note">Tip: Click a row to edit. Difference = Budget − Actual.</div>
         </div>
-      </div>
-    </section>
+      </section>
 
     <section id="panel-transactions" role="tabpanel" class="hidden">
       <div class="grid">

--- a/readme.md
+++ b/readme.md
@@ -14,5 +14,8 @@ Delete and edit buttons now mirror the shape of primary actions while using a di
 ### Money In Editing
 Income entries can now be edited. Use the new edit button next to each income to modify its name or amount.
 
+### Budget Layout
+The Overview charts have been removed. The Money Out – Categories table now appears alongside Money In on the budget screen for easier access.
+
 ## Tests
 Run `npm test` to verify the project is set up correctly.


### PR DESCRIPTION
## Summary
- remove overview charts and move Money Out – Categories card into the main budget grid
- drop related chart rendering from app logic
- document layout change in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa14251208832fbc147554b0d6a207