### PR TITLE
Rework transactions layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -262,11 +262,10 @@
       learnList: document.getElementById('learn-list'),
 
       // Charts
-      barCategories: document.getElementById('bar-categories'),
-      donutActual: document.getElementById('donut-actual'),
-      donutBudget: document.getElementById('donut-budget'),
-      barPerCat: document.getElementById('bar-percat')
-    };
+        barCategories: document.getElementById('bar-categories'),
+        donutActual: document.getElementById('donut-actual'),
+        donutBudget: document.getElementById('donut-budget')
+      };
 
     let currentMonthKey = Utils.monthKey();
     let editingIncomeId = null;
@@ -399,12 +398,7 @@
       Charts.donut(els.donutBudget, Object.fromEntries(groups.map(g=>[g,t.groups[g].budget])));
       Charts.donut(els.donutActual, Object.fromEntries(groups.map(g=>[g,t.groups[g].actual])));
 
-      // Per-category bar
-      const cats = Object.keys(month.categories).sort();
-      const b2 = cats.map(c=>month.categories[c].budget||0);
-      const a2 = cats.map(c=>t.actualPerCat[c]||0);
-      Charts.bar(els.barPerCat, cats, [b2,a2]);
-    }
+      }
 
     // ---- Event wiring
     els.addIncome.onclick = ()=>{

--- a/index.html
+++ b/index.html
@@ -120,6 +120,13 @@
     <section id="panel-transactions" role="tabpanel" class="hidden">
       <div class="grid">
         <div class="card">
+          <h2>Monthly Transactions</h2>
+          <div class="content">
+            <div class="list" id="tx-list"></div>
+          </div>
+        </div>
+
+        <div class="card">
           <h2>Add Transaction</h2>
           <div class="content">
             <div class="row">
@@ -133,20 +140,6 @@
               <span id="predict-hint" class="badge">Prediction: –</span>
             </div>
           </div>
-        </div>
-
-        <div class="card">
-          <h2>Expenditure per Category</h2>
-          <div class="content">
-            <canvas id="bar-percat" height="360"></canvas>
-          </div>
-        </div>
-      </div>
-
-      <div class="card" style="margin-top:18px">
-        <h2>Monthly Transactions</h2>
-        <div class="content">
-          <div class="list" id="tx-list"></div>
         </div>
       </div>
     </section>

--- a/readme.md
+++ b/readme.md
@@ -14,5 +14,8 @@ Delete and edit buttons now mirror the shape of primary actions while using a di
 ### Money In Editing
 Income entries can now be edited. Use the new edit button next to each income to modify its name or amount.
 
+### Transactions Layout
+The Expenditure per Category chart has been removed. The Transactions tab now uses a two-column layout with Monthly Transactions on the left and the Add Transaction form on the right.
+
 ## Tests
 Run `npm test` to verify the project is set up correctly.

--- a/styles.css
+++ b/styles.css
@@ -34,7 +34,9 @@
     .tab{border:1px solid var(--border);background:var(--card);padding:8px 12px;border-radius:10px;cursor:pointer}
     .tab[aria-selected="true"]{background:#111827;color:#fff;border-color:#111827}
 
-    .grid{display:grid;grid-template-columns: 420px 1fr;gap:18px}
+.grid{display:grid;grid-template-columns: 420px 1fr;gap:18px}
+
+#panel-transactions .grid{grid-template-columns:1fr 420px}
 
     .card{background:var(--card);border:1px solid var(--border);border-radius:14px;box-shadow:0 2px 6px rgba(0,0,0,.04)}
     .card h2{margin:0;padding:12px 14px;border-bottom:1px solid var(--border);font-size:16px}


### PR DESCRIPTION
## Summary
- remove "Expenditure per Category" chart
- show monthly transactions alongside add-transaction form in two-column layout
- document new transaction layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa14d68da0832f897038f844358989