### PR TITLE
Remove default budget template

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -386,9 +386,10 @@
     };
 
     els.resetTemplate.onclick = ()=>{
-      if(!confirm('Clear all categories for this month?')) return;
+      if(!confirm('Clear all categories and incomes for this month?')) return;
       const base = Model.template(); const m = Store.getMonth(currentMonthKey);
-      m.categories = base.categories; Store.setMonth(currentMonthKey,m); loadMonth(currentMonthKey);
+      m.categories = base.categories; m.incomes = base.incomes;
+      Store.setMonth(currentMonthKey,m); loadMonth(currentMonthKey);
     };
 
     // Collapse/Expand all groups

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
                 <input id="cat-group" placeholder="Group (e.g. Food)"/>
                 <input id="cat-budget" type="number" step="0.01" placeholder="Budget"/>
                 <button class="primary" id="add-category">Add/Update Category</button>
-                <button class="ghost" id="reset-template" title="Clear all categories from this month">Clear</button>
+                <button class="ghost" id="reset-template" title="Clear all categories and incomes from this month">Clear</button>
                 <button class="ghost" id="collapse-all" title="Collapse all groups">Collapse All</button>
                 <button class="ghost" id="expand-all" title="Expand all groups">Expand All</button>
               </div>

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This repository contains a simple monthly home budgeting app.
 ## Usage
 Open `index.html` in a browser to track your income and expenses for each month. The app now uses 95% of your screen width to provide a wider workspace.
 
-The app now starts with no pre-filled categories or incomes. Use the provided controls to add your own data from scratch. The *Clear* button in the categories section removes all categories for the current month.
+The app now starts with no pre-filled categories or incomes. Use the provided controls to add your own data from scratch. The *Clear* button in the categories section removes all categories and incomes for the current month.
 
 ## File Structure
 JavaScript files are located in `app/js` and stylesheets in `app/css`.


### PR DESCRIPTION
## Summary
- Start each new budget with a completely empty template so users can define their own categories and incomes.
- Rename the "Template" button to "Clear" and adjust its confirmation text to clarify that it removes all categories.
- Update documentation to note the blank starting state and how to clear categories.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa300c4d54832f9f3c027d3e226b4a