### PR TITLE
style: darken header orange for better contrast

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -1,5 +1,5 @@
     :root{
-      --brand:#ff7a00; /* header accent */
+      --brand:#d45e00; /* header accent */
       --ink:#1f2937;
       --sub:#6b7280;
       --bg:#f8fafc;
@@ -14,7 +14,7 @@
     html,body{height:100%}
     body{margin:0;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;color:var(--ink);background:var(--bg)}
     header{
-      position:sticky;top:0;z-index:10;background:linear-gradient(90deg,var(--brand),#ffa733);
+      position:sticky;top:0;z-index:10;background:linear-gradient(90deg,var(--brand),#ff8800);
       color:white;padding:14px 18px;box-shadow:0 2px 6px rgba(0,0,0,.08);
       display:flex;align-items:center;gap:14px
     }


### PR DESCRIPTION
## Summary
- deepen header brand color for improved contrast
- adjust header gradient to new darker orange

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa327edae0832fbba74770a313f0a3