### PR TITLE
Remove default Salary and Vala income seed data

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -245,9 +245,7 @@
       if(Store.allMonths().length===0){
         const mk = Utils.monthKey(new Date());
         const month = Model.template();
-        // Seed example incomes (can be edited)
-        Model.addIncome(month,'Salary',4705.66);
-        Model.addIncome(month,'Vala',212.28);
+        // Initialize with an empty month; no default incomes
         Store.setMonth(mk, month);
       }
       currentMonthKey = Store.allMonths().slice(-1)[0] || Utils.monthKey();

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This repository contains a simple monthly home budgeting app.
 ## Usage
 Open `index.html` in a browser to track your income and expenses for each month. The app now uses 95% of your screen width to provide a wider workspace.
 
-The app now starts with no pre-filled categories or incomes. Use the provided controls to add your own data from scratch. The *Clear* button in the categories section removes all categories and incomes for the current month.
+The app now starts with no pre-filled categories or incomes. Previously seeded "Salary" and "Vala" income examples have been removed, so you can build your budget entirely from scratch. The *Clear* button in the categories section removes all categories and incomes for the current month.
 
 ## File Structure
 JavaScript files are located in `app/js` and stylesheets in `app/css`.


### PR DESCRIPTION
## Summary
- stop seeding example "Salary" and "Vala" incomes during initialisation
- update README to mention removal of default income examples

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3437c2b8832f9832d1bf68351c42