### PR TITLE
feat: suggest transaction descriptions

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -67,6 +67,7 @@
     .list-item small{color:var(--sub)}
 
     .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:var(--muted)}
+    .tooltip{display:inline-block;padding:4px 8px;border-radius:4px;background:var(--muted);font-size:12px;margin-top:4px}
     .right{text-align:right}
     .success{color:var(--ok)}
     .danger{color:var(--err)}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -271,6 +271,7 @@
       txList: document.getElementById('tx-list'),
       predictHint: document.getElementById('predict-hint'),
       descPredictHint: document.getElementById('desc-predict-hint'),
+      descTooltip: document.getElementById('desc-tooltip'),
 
       // Learning
       learnDesc: document.getElementById('learn-desc'),
@@ -282,6 +283,8 @@
     let currentMonthKey = Utils.monthKey();
     let editingIncomeId = null;
     els.descPredictHint.textContent = 'Desc: –';
+    els.descTooltip.classList.add('hidden');
+    let descSuggestion = '';
 
     // ---- init data if empty
     (function bootstrap(){
@@ -451,8 +454,27 @@
       const guess = Predictor.predict(els.txDesc.value, cats);
       els.predictHint.textContent = 'Prediction: '+(guess||'–');
       if(guess){ els.txCat.value = guess; }
-      const dGuess = DescPredictor.predict(els.txDesc.value);
+      const val = els.txDesc.value;
+      const dGuess = DescPredictor.predict(val);
       els.descPredictHint.textContent = 'Desc: '+(dGuess||'–');
+      if(dGuess && dGuess.toLowerCase() !== val.trim().toLowerCase()){
+        descSuggestion = dGuess;
+        els.descTooltip.textContent = `${dGuess} (press space to accept)`;
+        els.descTooltip.classList.remove('hidden');
+      }else{
+        descSuggestion = '';
+        els.descTooltip.classList.add('hidden');
+      }
+    });
+
+    els.txDesc.addEventListener('keydown', (e)=>{
+      if(e.key === ' ' && descSuggestion){
+        e.preventDefault();
+        els.txDesc.value = descSuggestion + ' ';
+        descSuggestion = '';
+        els.descTooltip.classList.add('hidden');
+        els.txDesc.dispatchEvent(new Event('input'));
+      }
     });
 
     els.addTx.onclick = ()=>{
@@ -463,6 +485,8 @@
       DescPredictor.learn(desc);
       els.txDesc.value=''; els.txAmt.value=''; renderTransactions(m);
       els.descPredictHint.textContent = 'Desc: –';
+      els.descTooltip.classList.add('hidden');
+      descSuggestion = '';
     };
 
     // Learning panel

--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
               <input id="tx-amt" type="number" step="0.01" placeholder="Amount (positive = spend)" />
               <select id="tx-cat"></select>
             </div>
+            <div id="desc-tooltip" class="tooltip hidden"></div>
             <div class="row">
               <button class="primary" id="add-tx">Add</button>
               <span id="predict-hint" class="badge">Prediction: –</span>

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ The Overview charts have been removed. The Money Out – Categories table now ap
 The transactions screen now shows the monthly transaction list next to the add transaction form in an 80/20 two-column layout (list left, form right). The former Expenditure per Category chart has been removed.
 
 ### Description Prediction
-As you type a transaction description, the app now suggests a previously used description based on your past entries. The most likely match is shown next to the Add button and updates as you type.
+As you type a transaction description, the app suggests a previously used description based on your past entries. A tooltip beneath the field shows the best match; press the space bar to accept the suggestion and the description will auto‑fill.
 
 ## Tests
 Run `npm test` to verify the project is set up correctly.


### PR DESCRIPTION
## Summary
- store description frequency map and expose helper functions
- predict previously used descriptions while typing a transaction
- document description prediction feature

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa34c14888832f893403cbcda37e0a