### PR TITLE
Remove category reset and style expand/collapse controls

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -57,7 +57,6 @@
     input,select{width:100%;padding:8px;border-radius:8px;border:1px solid var(--border);background:#fff}
     button.primary{background:var(--ink);color:#fff;border:0;padding:8px 12px;border-radius:10px;cursor:pointer}
     button.secondary{background:var(--sub);color:#fff;border:0;padding:8px 12px;border-radius:10px;cursor:pointer}
-    button.ghost{background:transparent;border:1px dashed var(--border);}
 
     .two-col{display:grid;grid-template-columns:4fr 1fr;gap:18px;align-items:start}
     .charts{display:grid;grid-template-columns:1fr 1fr;gap:18px}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -254,7 +254,6 @@
       catGroup: document.getElementById('cat-group'),
       catBudget: document.getElementById('cat-budget'),
       addCategory: document.getElementById('add-category'),
-      resetTemplate: document.getElementById('reset-template'),
       collapseAll: document.getElementById('collapse-all'),
       expandAll: document.getElementById('expand-all'),
       catTable: document.getElementById('category-table').querySelector('tbody'),
@@ -427,13 +426,6 @@
       if(!name) return;
       const m = Store.getMonth(currentMonthKey); Model.setCat(m,name,group,bud); Store.setMonth(currentMonthKey,m);
       els.catName.value=''; els.catGroup.value=''; els.catBudget.value=''; loadMonth(currentMonthKey);
-    };
-
-    els.resetTemplate.onclick = ()=>{
-      if(!confirm('Clear all categories and incomes for this month?')) return;
-      const base = Model.template(); const m = Store.getMonth(currentMonthKey);
-      m.categories = base.categories; m.incomes = base.incomes;
-      Store.setMonth(currentMonthKey,m); loadMonth(currentMonthKey);
     };
 
     // Collapse/Expand all groups

--- a/index.html
+++ b/index.html
@@ -66,9 +66,8 @@
                 <input id="cat-group" placeholder="Group (e.g. Food)"/>
                 <input id="cat-budget" type="number" step="0.01" placeholder="Budget"/>
                 <button class="primary" id="add-category">Add/Update Category</button>
-                <button class="ghost" id="reset-template" title="Clear all categories and incomes from this month">Clear</button>
-                <button class="ghost" id="collapse-all" title="Collapse all groups">Collapse All</button>
-                <button class="ghost" id="expand-all" title="Expand all groups">Expand All</button>
+                <button class="secondary" id="collapse-all" title="Collapse all groups">Collapse All</button>
+                <button class="secondary" id="expand-all" title="Expand all groups">Expand All</button>
               </div>
 
               <table class="table" id="category-table">

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This repository contains a simple monthly home budgeting app.
 ## Usage
 Open `index.html` in a browser to track your income and expenses for each month. The app now uses 95% of your screen width to provide a wider workspace.
 
-The app now starts with no pre-filled categories or incomes. Previously seeded "Salary" and "Vala" income examples have been removed, so you can build your budget entirely from scratch. The *Clear* button in the categories section removes all categories and incomes for the current month.
+The app now starts with no pre-filled categories or incomes. Previously seeded "Salary" and "Vala" income examples have been removed, so you can build your budget entirely from scratch. The previous *Clear* button has been removed; delete categories individually or start a new month if you need a blank slate. Categories can be collapsed or expanded using the secondary-styled controls above the table.
 
 ## File Structure
 JavaScript files are located in `app/js` and stylesheets in `app/css`.


### PR DESCRIPTION
## Summary
- Remove obsolete Clear button from Money Out categories
- Style Collapse All and Expand All category controls with secondary button styling
- Drop unused ghost button styles and update documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa45a460f0832f9efc0bc757a4e7e5