### PR TITLE
Style transaction list amounts and spacing

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -65,6 +65,8 @@
     .list{max-height:320px;overflow:auto;border:1px solid var(--border);border-radius:10px}
     .list-item{display:flex;justify-content:space-between;gap:8px;padding:8px 10px;border-bottom:1px solid var(--border)}
     .list-item small{color:var(--sub)}
+    .list-item .right>div:first-child{padding-right:10px;font-weight:bold;font-size:1.2em}
+    .list-item .right button{padding-right:10px}
 
     .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:var(--muted)}
     .tooltip{display:inline-block;padding:4px 8px;border-radius:4px;background:var(--muted);font-size:12px;margin-top:4px}

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ The transactions screen now shows the monthly transaction list next to the add t
 
 The transaction list now fills nearly the entire screen without overflowing and scrolls within its card, while the add transaction form retains its original size.
 
+Prices in the monthly transaction list are now larger, bold, and include extra right padding alongside the delete button for improved readability.
+
 ### Description Prediction
 As you type a transaction description, the app suggests a previously used description based on your past entries. A tooltip beneath the field shows the best match; press the space bar to accept the suggestion and the description will auto‑fill.
 


### PR DESCRIPTION
## Summary
- Add right padding to transaction amounts and delete buttons for improved spacing.
- Bold and enlarge transaction amounts for better readability.
- Document transaction list styling enhancement in README.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa463378e4832fa7130302419ab85e