### PR TITLE
feat: improve add transaction entry

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -468,10 +468,12 @@
         els.txDesc.dispatchEvent(new Event('input'));
       }
     });
-
-    els.addTx.onclick = ()=>{
-      const date = els.txDate.value || new Date().toISOString().slice(0,10);
-      const desc = els.txDesc.value.trim(); const amt = parseFloat(els.txAmt.value||'0'); const cat = els.txCat.value;
+    const handleAddTx = ()=>{
+      const date = els.txDate.value.trim();
+      const desc = els.txDesc.value.trim();
+      const amt = parseFloat(els.txAmt.value);
+      const cat = els.txCat.value;
+      if(!date || !desc || isNaN(amt)) return;
       const m = Store.getMonth(currentMonthKey); Model.addTx(m,{date,desc,amount:amt,category:cat}); Store.setMonth(currentMonthKey,m);
       Predictor.learn(desc,cat);
       DescPredictor.learn(desc);
@@ -479,7 +481,16 @@
       els.descPredictHint.textContent = 'Desc: –';
       els.descTooltip.classList.add('hidden');
       descSuggestion = '';
+      els.txDesc.focus();
     };
+
+    els.addTx.onclick = handleAddTx;
+
+    [els.txDate, els.txDesc, els.txAmt, els.txCat].forEach(el=>{
+      el.addEventListener('keydown', (e)=>{
+        if(e.key === 'Enter') handleAddTx();
+      });
+    });
 
     // Learning panel
     els.learnAdd.onclick = ()=>{ Predictor.learn(els.learnDesc.value, els.learnCat.value); DescPredictor.learn(els.learnDesc.value); els.learnDesc.value=''; renderLearnList(); };

--- a/readme.md
+++ b/readme.md
@@ -32,5 +32,8 @@ Prices in the monthly transaction list are now larger, bold, and include extra r
 ### Description Prediction
 As you type a transaction description, the app suggests a previously used description based on your past entries. A tooltip beneath the field shows the best match; press the space bar to accept the suggestion and the description will auto‑fill.
 
+### Add Transaction Shortcuts
+The add transaction form now requires a date, description and amount before a transaction can be added. Pressing <kbd>Enter</kbd> in any field triggers the add action, and focus returns to the description field to speed up entry of multiple transactions.
+
 ## Tests
 Run `npm test` to verify the project is set up correctly.


### PR DESCRIPTION
## Summary
- require date, description, and amount before adding a transaction
- support pressing Enter to add transactions and refocus description field
- document new transaction entry behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa49abb4d4832fb2e539e5c4585907