### PR TITLE
Ensure category totals refresh with new transactions

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -478,7 +478,7 @@
       const m = Store.getMonth(currentMonthKey); Model.addTx(m,{date,desc,amount:amt,category:cat}); Store.setMonth(currentMonthKey,m);
       Predictor.learn(desc,cat);
       DescPredictor.learn(desc);
-      els.txDesc.value=''; els.txAmt.value=''; renderTransactions(m);
+      els.txDesc.value=''; els.txAmt.value=''; renderTransactions(m); renderCategories(m);
       els.descPredictHint.textContent = 'Desc: –';
       els.descTooltip.classList.add('hidden');
       descSuggestion = '';

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,9 @@ The transaction list now fills nearly the entire screen without overflowing and 
 
 Prices in the monthly transaction list are now larger, bold, and include extra right padding alongside the delete button for improved readability.
 
+### Real-time Category Totals
+The Money Out – Categories table refreshes instantly when you add new transactions so actual and difference values are always up to date.
+
 ### Description Prediction
 As you type a transaction description, the app looks up your past entries that are stored in your browser's local storage. Only unique descriptions are kept. A tooltip beneath the field shows the best match; press the space bar to accept the suggestion and the description will auto‑fill.
 


### PR DESCRIPTION
## Summary
- Refresh Money Out – Categories table when transactions are added so budget totals stay current
- Document real-time category updates in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa51928804832fbd2dd72c042bc89f