### PR TITLE
Add spacing in Add Transaction form

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -53,6 +53,7 @@
     .kpi strong{display:block;font-size:18px}
 
     .row{display:flex;gap:10px;flex-wrap:wrap}
+    .row + .row{margin-top:10px}
     .row > *{flex:1 1 160px}
     input,select{width:100%;padding:8px;border-radius:8px;border:1px solid var(--border);background:#fff}
     button.primary{background:var(--ink);color:#fff;border:0;padding:8px 12px;border-radius:10px;cursor:pointer}

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ The transactions screen now shows the monthly transaction list next to the add t
 
 The transaction list now fills nearly the entire screen without overflowing and scrolls within its card, while the add transaction form retains its original size.
 
+A small gap now separates the category selector from the Add button for clearer entry.
+
 Prices in the monthly transaction list are now larger, bold, and include extra right padding alongside the delete button for improved readability.
 
 ### Real-time Category Totals


### PR DESCRIPTION
## Summary
- add margin between stacked rows so the category selector and Add button are separated
- document the updated Add Transaction spacing in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa54b439a0832fada22284771c993e