### PR TITLE
Group transactions by calendar day

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -67,6 +67,7 @@
     .list-item small{color:var(--sub)}
     .list-item .right>div:first-child{padding-right:10px;font-weight:bold;font-size:1.2em}
     .list-item .right button{padding-right:10px}
+    .tx-date{padding:8px 10px;background:var(--muted);font-weight:700;border-bottom:1px solid var(--border)}
 
     .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:var(--muted)}
     .tooltip{display:inline-block;padding:4px 8px;border-radius:4px;background:var(--muted);font-size:12px;margin-top:4px}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -387,12 +387,20 @@
     function renderTransactions(month){
       els.txList.innerHTML='';
       const items = month.transactions.slice().sort((a,b)=> a.date.localeCompare(b.date));
-      for(const t of items){
-        const row = document.createElement('div'); row.className='list-item';
-        row.innerHTML = `<div><strong>${t.desc}</strong><div><small>${t.date} • ${t.category||'Uncategorised'}</small></div></div>
-                         <div class="right"><div>${Utils.fmt(t.amount)}</div><small><button class="secondary" data-id="${t.id}">Delete</button></small></div>`;
-        row.querySelector('button').onclick = ()=>{ const m=Store.getMonth(currentMonthKey); Model.delTx(m,t.id); Store.setMonth(currentMonthKey,m); loadMonth(currentMonthKey); };
-        els.txList.appendChild(row);
+      const byDate = Utils.groupBy(items, t=>t.date);
+      const dates = Object.keys(byDate).sort();
+      for(const date of dates){
+        const hdr = document.createElement('div');
+        hdr.className = 'tx-date';
+        hdr.textContent = new Date(date).toLocaleDateString(undefined,{weekday:'short', day:'numeric', month:'short'});
+        els.txList.appendChild(hdr);
+        for(const t of byDate[date]){
+          const row = document.createElement('div'); row.className='list-item';
+          row.innerHTML = `<div><strong>${t.desc}</strong><div><small>${t.category||'Uncategorised'}</small></div></div>`+
+                           `<div class="right"><div>${Utils.fmt(t.amount)}</div><small><button class="secondary" data-id="${t.id}">Delete</button></small></div>`;
+          row.querySelector('button').onclick = ()=>{ const m=Store.getMonth(currentMonthKey); Model.delTx(m,t.id); Store.setMonth(currentMonthKey,m); loadMonth(currentMonthKey); };
+          els.txList.appendChild(row);
+        }
       }
       refreshKPIs();
     }

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,8 @@ A small gap now separates the category selector from the Add button for clearer 
 
 Prices in the monthly transaction list are now larger, bold, and include extra right padding alongside the delete button for improved readability.
 
+Transactions are grouped by calendar day, with each date shown as a header followed by that day's entries.
+
 ### Real-time Category Totals
 The Money Out – Categories table refreshes instantly when you add new transactions so actual and difference values are always up to date.
 


### PR DESCRIPTION
## Summary
- group monthly transactions by date with daily headers
- style daily headers and update docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa5d0a1788832fba09eb478ff951fd