### PR TITLE
Add bottom spacing for Monthly Transactions card

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -78,6 +78,6 @@
     .hidden{display:none}
 
     /* Fit transaction list card within viewport */
-    #panel-transactions .card:first-child{height:calc(100vh - 120px);display:flex;flex-direction:column}
+    #panel-transactions .card:first-child{height:calc(100vh - 140px);display:flex;flex-direction:column}
     #panel-transactions .card:first-child .content{flex:1;display:flex;flex-direction:column;min-height:0;overflow:hidden}
     #tx-list{flex:1;overflow:auto;max-height:none}

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ The transactions screen now shows the monthly transaction list next to the add t
 
 The transaction list now fills nearly the entire screen without overflowing and scrolls within its card, while the add transaction form retains its original size.
 
+The monthly transactions card now leaves a 20px gap from the bottom of the screen for clearer separation from the edge.
+
 Prices in the monthly transaction list are now larger, bold, and include extra right padding alongside the delete button for improved readability.
 
 ### Real-time Category Totals


### PR DESCRIPTION
## Summary
- Reduce Monthly Transactions card height so it sits 20px above the viewport bottom
- Document new bottom spacing in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa54f791ac832f9d590c529da0ffaa