### PR TITLE
Add numbering and layout tweaks to monthly transactions

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -63,10 +63,11 @@
     .charts{display:grid;grid-template-columns:1fr 1fr;gap:18px}
 
     .list{max-height:320px;overflow:auto;border:1px solid var(--border);border-radius:10px}
-    .list-item{display:flex;justify-content:space-between;gap:8px;padding:8px 10px;border-bottom:1px solid var(--border)}
+    .list-item{display:flex;align-items:center;gap:8px;padding:8px 10px;border-bottom:1px solid var(--border)}
     .list-item small{color:var(--sub)}
-    .list-item .right>div:first-child{padding-right:10px;font-weight:bold;font-size:1.2em}
-    .list-item .right button:not(.icon-btn){padding-right:10px}
+    .list-item .grow{flex:1}
+    .list-item .tx-index{width:24px;color:var(--sub)}
+    .list-item .tx-amount{text-align:right;font-weight:bold;font-size:1.2em;margin-right:16px}
     .tx-date{padding:8px 10px;background:var(--muted);font-weight:700;border-bottom:1px solid var(--border)}
 
     .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:var(--muted)}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -352,7 +352,7 @@
 
     function addIncomeRow(x){
       const row = document.createElement('div'); row.className='list-item';
-      row.innerHTML = `<div><strong>${x.name}</strong><div><small>${Utils.fmt(x.amount)}</small></div></div>`+
+      row.innerHTML = `<div class="grow"><strong>${x.name}</strong><div><small>${Utils.fmt(x.amount)}</small></div></div>`+
                       `<div class="actions"><button class="icon-btn" data-act="edit" aria-label="Edit">${ICON_EDIT}</button> <button class="icon-btn" data-act="del" aria-label="Delete">${ICON_DELETE}</button></div>`;
       row.onclick = async (e)=>{
         const act = e.target.closest('button')?.dataset?.act; if(!act) return;
@@ -420,6 +420,7 @@
       const items = month.transactions.slice().sort((a,b)=> a.date.localeCompare(b.date));
       const byDate = Utils.groupBy(items, t=>t.date);
       const dates = Object.keys(byDate).sort();
+      let idx = 1;
       for(const date of dates){
         const hdr = document.createElement('div');
         hdr.className = 'tx-date';
@@ -427,8 +428,10 @@
         els.txList.appendChild(hdr);
         for(const t of byDate[date]){
           const row = document.createElement('div'); row.className='list-item';
-          row.innerHTML = `<div><strong>${t.desc}</strong><div><small>${t.category||'Uncategorised'}</small></div></div>`+
-                           `<div class="right"><div>${Utils.fmt(t.amount)}</div><div class="actions"><button class="icon-btn" data-act="edit" data-id="${t.id}" aria-label="Edit">${ICON_EDIT}</button> <button class="icon-btn" data-act="del" data-id="${t.id}" aria-label="Delete">${ICON_DELETE}</button></div></div>`;
+          row.innerHTML = `<div class="tx-index">${idx++}</div>`+
+                           `<div class="grow"><strong>${t.desc}</strong><div><small>${t.category||'Uncategorised'}</small></div></div>`+
+                           `<div class="tx-amount">${Utils.fmt(t.amount)}</div>`+
+                           `<div class="actions"><button class="icon-btn" data-act="edit" data-id="${t.id}" aria-label="Edit">${ICON_EDIT}</button> <button class="icon-btn" data-act="del" data-id="${t.id}" aria-label="Delete">${ICON_DELETE}</button></div>`;
           row.querySelector('[data-act="del"]').onclick = async ()=>{
             if(await Dialog.confirm('Delete this transaction?')){ const m=Store.getMonth(currentMonthKey); Model.delTx(m,t.id); Store.setMonth(currentMonthKey,m); loadMonth(currentMonthKey); }
           };

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ The transaction list now fills nearly the entire screen without overflowing and 
 The monthly transactions card now leaves a 20px gap from the bottom of the screen for clearer separation from the edge.
 A small gap now separates the category selector from the Add button for clearer entry.
 
-Prices in the monthly transaction list are now larger, bold, and include extra right padding alongside the delete button for improved readability.
+Each transaction row now begins with a row number. Prices remain large and bold, and now sit to the left of the edit/delete icons with extra spacing for clearer separation.
 
 ### Transaction Editing
 Each monthly transaction entry includes an edit icon so existing records can be updated.


### PR DESCRIPTION
## Summary
- Number each monthly transaction row to improve reference
- Show transaction amount before action buttons with extra spacing
- Note the new layout and spacing in documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa6497ad08832f94bd25cbe42bfaa2