### PR TITLE
Display total in Monthly Transactions header

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -37,7 +37,7 @@
     .grid{display:grid;grid-template-columns: 420px 1fr;gap:18px}
 
     .card{background:var(--card);border:1px solid var(--border);border-radius:14px;box-shadow:0 2px 6px rgba(0,0,0,.04)}
-    .card h2{margin:0;padding:12px 14px;border-bottom:1px solid var(--border);font-size:16px}
+    .card h2{margin:0;padding:12px 14px;border-bottom:1px solid var(--border);font-size:16px;display:flex;justify-content:space-between;align-items:center}
     .card .content{padding:12px 14px}
 
     .table{width:100%;border-collapse:collapse}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -292,6 +292,7 @@
       txCat: document.getElementById('tx-cat'),
       addTx: document.getElementById('add-tx'),
       txList: document.getElementById('tx-list'),
+      txTotal: document.getElementById('tx-total'),
       predictHint: document.getElementById('predict-hint'),
       descPredictHint: document.getElementById('desc-predict-hint'),
       descTooltip: document.getElementById('desc-tooltip'),
@@ -439,6 +440,8 @@
           els.txList.appendChild(row);
         }
       }
+      const totals = Model.totals(month);
+      els.txTotal.textContent = Utils.fmt(totals.actualTotal);
       refreshKPIs();
     }
 

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
     <section id="panel-transactions" role="tabpanel" class="hidden">
       <div class="two-col">
         <div class="card">
-          <h2>Monthly Transactions</h2>
+          <h2><span>Monthly Transactions</span><span id="tx-total">£0.00</span></h2>
           <div class="content">
             <div class="list" id="tx-list"></div>
           </div>

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,8 @@ The transactions screen now shows the monthly transaction list next to the add t
 
 The transaction list now fills nearly the entire screen without overflowing and scrolls within its card, while the add transaction form retains its original size.
 
+The Monthly Transactions header now displays the total value of all transactions for the month on the right.
+
 The monthly transactions card now leaves a 20px gap from the bottom of the screen for clearer separation from the edge.
 A small gap now separates the category selector from the Add button for clearer entry.
 


### PR DESCRIPTION
## Summary
- Show monthly transaction total alongside Monthly Transactions heading for quick context.
- Flex card headers to support right-aligned totals.
- Document new header total in README.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa661e8780832f8ed886ee114528fb