### PR TITLE
Add monthly transaction import dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,7 @@
       <button id="export-month">Export Month</button>
       <button id="export-year">Export Year</button>
       <button id="export-all">Export All</button>
-      <label class="inline-field" style="cursor:pointer">
-        <span>Import</span>
-        <input id="import-file" type="file" accept="application/json" style="display:none"/>
-      </label>
+      <button id="import-trans">Import</button>
     </div>
   </header>
 
@@ -144,6 +141,28 @@
       </div>
     </section>
   </main>
+  <dialog id="import-dialog" class="dialog">
+    <div class="dialog-content">
+      <div class="row">
+        <label>Month <input type="month" id="import-month"/></label>
+      </div>
+      <div class="row">
+        <label>File Type
+          <select id="import-type">
+            <option value="json">JSON</option>
+            <option value="csv">CSV</option>
+          </select>
+        </label>
+      </div>
+      <div class="row">
+        <input id="import-file" type="file" accept="application/json,.json,.csv"/>
+      </div>
+      <div class="dialog-actions">
+        <button id="import-confirm" class="primary">Import</button>
+        <button id="import-cancel" class="secondary">Cancel</button>
+      </div>
+    </div>
+  </dialog>
   <dialog id="dialog" class="dialog">
     <div class="dialog-content">
       <p id="dialog-message"></p>

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,9 @@ Each monthly transaction entry includes an edit icon so existing records can be 
 
 Transactions are grouped by calendar day, with each date shown as a header followed by that day's entries.
 
+### Import Monthly Transactions
+Use the **Import** button to load transactions for a specific month. A dialog lets you choose the budget month and whether the file is JSON or CSV. Files should contain rows with date, description, amount and category; imported entries are added to the chosen month.
+
 ### Real-time Category Totals
 The Money Out – Categories table refreshes instantly when you add new transactions so actual and difference values are always up to date.
 


### PR DESCRIPTION
## Summary
- support importing transactions for a selected month from CSV or JSON
- add dialog allowing month and file type selection before import
- document import workflow in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac4843fac832f92b5a0a439121d3b