### PR TITLE
Display daily and running totals for transactions

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -69,7 +69,8 @@
     .list-item .grow{flex:1}
     .list-item .tx-index{width:24px;color:var(--sub)}
     .list-item .tx-amount{text-align:right;font-weight:bold;font-size:1.2em;margin-right:16px}
-    .tx-date{padding:8px 10px;background:var(--muted);font-weight:700;border-bottom:1px solid var(--border)}
+    .tx-date{padding:8px 10px;background:var(--muted);font-weight:700;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px}
+    .tx-date .totals{display:flex;gap:12px;font-weight:400}
 
     .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:var(--muted)}
     .tooltip{display:inline-block;padding:4px 8px;border-radius:4px;background:var(--muted);font-size:12px;margin-top:4px}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -489,12 +489,25 @@
       const byDate = Utils.groupBy(items, t=>t.date);
       const dates = Object.keys(byDate).sort();
       let idx = 1;
-        for(const date of dates){
-          const hdr = document.createElement('div');
-          hdr.className = 'tx-date';
-          hdr.textContent = new Date(date).toLocaleDateString(undefined,{weekday:'short', day:'numeric', month:'short'});
-          els.txList.appendChild(hdr);
-          for(const t of byDate[date]){
+      let runningTotal = 0;
+      for(const date of dates){
+        const dayTotal = Utils.sum(byDate[date], t=>t.amount);
+        runningTotal += dayTotal;
+
+        const hdr = document.createElement('div');
+        hdr.className = 'tx-date';
+        const dateLabel = new Date(date).toLocaleDateString(undefined,{weekday:'short', day:'numeric', month:'short'});
+        hdr.innerHTML = `<span>${dateLabel}</span>`+
+                        `<span class="totals"><span class="day"></span><span class="run"></span></span>`;
+        const dayEl = hdr.querySelector('.day');
+        dayEl.textContent = `Day: ${Utils.fmt(dayTotal)}`;
+        if(dayTotal < 0) dayEl.classList.add('danger');
+        const runEl = hdr.querySelector('.run');
+        runEl.textContent = `Total: ${Utils.fmt(runningTotal)}`;
+        if(runningTotal < 0) runEl.classList.add('danger');
+        els.txList.appendChild(hdr);
+
+        for(const t of byDate[date]){
             const row = document.createElement('div'); row.className='list-item';
             const aCls = t.amount<0?'danger':'';
             row.innerHTML = `<div class="tx-index">${idx++}</div>`+
@@ -508,10 +521,10 @@
           els.txList.appendChild(row);
         }
       }
-        const totals = Model.totals(month);
-        Utils.setText(els.txTotal, totals.actualTotal);
-        refreshKPIs();
-      }
+      const totals = Model.totals(month);
+      Utils.setText(els.txTotal, totals.actualTotal);
+      refreshKPIs();
+    }
 
         function refreshKPIs(){
           const month = Store.getMonth(currentMonthKey);

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,7 @@ Each transaction row now begins with a row number. Prices remain large and bold,
 Each monthly transaction entry includes an edit icon so existing records can be updated.
 
 Transactions are grouped by calendar day, with each date shown as a header followed by that day's entries.
+Each header also displays the day's total spend and the running total for the month so far.
 
 ### Import & Export Data
 Use the **Import** and **Export** buttons to move data in or out of the app. A pop‑up dialog lets you choose the dataset:


### PR DESCRIPTION
## Summary
- show each day's total spend and cumulative spend in monthly transaction list
- style transaction date headers with flexible layout for new totals
- document daily and running totals in transaction section of README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab0604935c832fa3ccbb2678caafb1