### PR TITLE
style: align transaction amount font size

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -68,7 +68,7 @@
     .list-item .danger{color:var(--err)}
     .list-item .grow{flex:1}
     .list-item .tx-index{width:24px;color:var(--sub)}
-    .list-item .tx-amount{text-align:right;font-weight:bold;font-size:1.2em;margin-right:16px}
+    .list-item .tx-amount{text-align:right;font-weight:bold;font-size:1em;margin-right:16px}
     .tx-date{padding:8px 10px;background:var(--muted);font-weight:700;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px}
     .tx-date .totals{display:flex;gap:12px;font-weight:400}
 

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ The Monthly Transactions header now displays the total value of all transactions
 The monthly transactions card now leaves a 20px gap from the bottom of the screen for clearer separation from the edge.
 A small gap now separates the category selector from the Add button for clearer entry.
 
-Each transaction row now begins with a row number. Prices remain large and bold, and now sit to the left of the edit/delete icons with extra spacing for clearer separation.
+Each transaction row now begins with a row number. Prices are bold, match the standard font size, and sit to the left of the edit/delete icons with extra spacing for clearer separation.
 
 ### Transaction Editing
 Each monthly transaction entry includes an edit icon so existing records can be updated.


### PR DESCRIPTION
## Summary
- Reduce transaction list amount font size to match standard text
- Document consistent font sizing for transaction amounts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab13f1263c832f9c8780d8d2bf2837