### PR TITLE
feat: add analysis tab with spending charts

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -792,7 +792,7 @@
       analysisChart = new Chart(ctx, {
         type:'bar',
         data:{ labels:months, datasets:[{label:'Budget',data:budgets,backgroundColor:'#3b82f6'},{label:'Actual',data:actuals,backgroundColor:'#f59e0b'}] },
-        options:{responsive:true, maintainAspectRatio:false}
+        options:{responsive:true, maintainAspectRatio:false, animation:false}
       });
       const diffs = months.map((mk,i)=>actuals[i]-budgets[i]);
       const maxDiff = Math.max(...diffs);

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <div class="tabs" role="tablist">
       <button class="tab" role="tab" id="tab-budget" aria-selected="true">Budget</button>
       <button class="tab" role="tab" id="tab-transactions" aria-selected="false">Transactions</button>
+      <button class="tab" role="tab" id="tab-analysis" aria-selected="false">Analysis</button>
       <button class="tab" role="tab" id="tab-learning" aria-selected="false">Prediction Map</button>
     </div>
 
@@ -124,6 +125,16 @@
       </div>
     </section>
 
+    <section id="panel-analysis" role="tabpanel" class="hidden">
+      <div class="card">
+        <h2>Spending Analysis</h2>
+        <div class="content">
+          <canvas id="analysis-chart"></canvas>
+          <div id="analysis-summary" class="footer-note"></div>
+        </div>
+      </div>
+    </section>
+
     <section id="panel-learning" role="tabpanel" class="hidden">
       <div class="card">
         <h2>Description → Category Map (auto‑learning)</h2>
@@ -210,6 +221,7 @@
     </div>
   </dialog>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="app/js/app.js"></script>
 </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,9 @@ A small gap now separates the category selector from the Add button for clearer 
 
 Each transaction row now begins with a row number. Prices are bold, match the standard font size, and sit to the left of the edit/delete icons with extra spacing for clearer separation.
 
+### Analysis Tab
+The **Analysis** tab compares monthly budgets with actual spending and highlights any overspending trends. A bar chart powered by Chart.js visualises the totals for each month so you can quickly spot patterns.
+
 ### Transaction Editing
 Each monthly transaction entry includes an edit icon so existing records can be updated.
 


### PR DESCRIPTION
## Summary
- add Analysis tab with Chart.js to compare monthly budgets vs actual spending
- include text summary for highest overspend month
- document new analysis view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab1cff3444832f9cbbbe64b145edf0