### PR TITLE
Show daily transaction counts

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -71,6 +71,7 @@
     .list-item .tx-amount{text-align:right;font-weight:bold;font-size:1em;margin-right:16px}
     .tx-date{padding:8px 10px;background:var(--muted);font-weight:700;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px}
     .tx-date .totals{display:flex;gap:12px;font-weight:400}
+    .tx-date .tx-count{margin-left:8px}
 
     .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:var(--muted)}
     .tooltip{display:inline-block;padding:4px 8px;border-radius:4px;background:var(--muted);font-size:12px;margin-top:4px}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -492,12 +492,13 @@
       let runningTotal = 0;
       for(const date of dates){
         const dayTotal = Utils.sum(byDate[date], t=>t.amount);
+        const dayCount = byDate[date].length;
         runningTotal += dayTotal;
 
         const hdr = document.createElement('div');
         hdr.className = 'tx-date';
         const dateLabel = new Date(date).toLocaleDateString(undefined,{weekday:'short', day:'numeric', month:'short'});
-        hdr.innerHTML = `<span>${dateLabel}</span>`+
+        hdr.innerHTML = `<span>${dateLabel}<span class="badge tx-count">${dayCount}</span></span>`+
                         `<span class="totals"><span class="day"></span><span class="run"></span></span>`;
         const dayEl = hdr.querySelector('.day');
         dayEl.textContent = `Day: ${Utils.fmt(dayTotal)}`;

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ Each transaction row now begins with a row number. Prices are bold, match the st
 Each monthly transaction entry includes an edit icon so existing records can be updated.
 
 Transactions are grouped by calendar day, with each date shown as a header followed by that day's entries.
-Each header also displays the day's total spend and the running total for the month so far.
+Each header also displays the number of transactions for that day, the day's total spend, and the running total for the month so far.
 
 ### Import & Export Data
 Use the **Import** and **Export** buttons to move data in or out of the app. A pop‑up dialog lets you choose the dataset:


### PR DESCRIPTION
## Summary
- display how many transactions occur each day and show count next to the date header
- style transaction count badge for day headers
- document daily transaction count in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8b2fd7f8832fbd377bfb9d2a98f7