### PR TITLE
feat: add multi-option description prediction

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -74,7 +74,9 @@
     .tx-date .tx-count{margin-left:8px;font-weight:400}
 
     .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:var(--muted)}
-    .tooltip{display:inline-block;padding:4px 8px;border-radius:4px;background:var(--muted);font-size:12px;margin-top:4px}
+    .tooltip{display:inline-block;padding:0;border-radius:4px;background:var(--muted);font-size:12px;margin-top:4px}
+    .tooltip .option{padding:4px 8px;cursor:pointer}
+    .tooltip .option.selected,.tooltip .option:hover{background:var(--sub);color:#fff}
     .right{text-align:right}
     .success{color:var(--ok)}
     .danger{color:var(--err)}

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ The Money Out – Categories table refreshes instantly when you add new transact
 Categories are global across months—add or edit a category once and it will appear in every monthly budget.
 
 ### Description Prediction
-As you type a transaction description, the app looks up your past entries that are stored in your browser's local storage. Only unique descriptions are kept. A tooltip beneath the field shows the best match; press the space bar to accept the suggestion and the description will auto‑fill.
+As you type a transaction description, the app looks up your past entries that are stored in your browser's local storage. Only unique descriptions are kept. A tooltip beneath the field now lists up to four matches. Use the up and down keys to highlight an option and press <kbd>Tab</kbd> or click to choose one; the description will auto‑fill.
 
 ### Add Transaction Shortcuts
 The add transaction form now requires a date, description and amount before a transaction can be added. Pressing <kbd>Enter</kbd> in any field triggers the add action, and focus returns to the description field to speed up entry of multiple transactions.


### PR DESCRIPTION
## Summary
- show up to four matching descriptions beneath the Add Transaction field
- allow navigating suggestions with arrow keys and selecting via Tab or click
- document description picker behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab909e2ae8832fb4b839d06cec8a4a