### PR TITLE
feat: add analysis tab placeholder

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -60,6 +60,7 @@
     button.secondary{background:var(--sub);color:#fff;border:0;padding:8px 12px;border-radius:10px;cursor:pointer}
 
     .two-col{display:grid;grid-template-columns:4fr 1fr;gap:18px;align-items:start}
+    .two-col-analysis{display:grid;grid-template-columns:1fr 4fr;gap:18px;align-items:start}
     .charts{display:grid;grid-template-columns:1fr 1fr;gap:18px}
 
     .list{max-height:320px;overflow:auto;border:1px solid var(--border);border-radius:10px}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -325,9 +325,11 @@
       // Tabs
       tabBudget: document.getElementById('tab-budget'),
       tabTx: document.getElementById('tab-transactions'),
+      tabAnalysis: document.getElementById('tab-analysis'),
       tabLearning: document.getElementById('tab-learning'),
       panelBudget: document.getElementById('panel-budget'),
       panelTx: document.getElementById('panel-transactions'),
+      panelAnalysis: document.getElementById('panel-analysis'),
       panelLearning: document.getElementById('panel-learning'),
 
       // Income
@@ -821,11 +823,17 @@
 
     // Tabs
     function selectTab(key){
-      const map = {budget:[els.tabBudget,els.panelBudget], tx:[els.tabTx,els.panelTx], learn:[els.tabLearning,els.panelLearning]};
+      const map = {
+        budget:[els.tabBudget,els.panelBudget],
+        tx:[els.tabTx,els.panelTx],
+        analysis:[els.tabAnalysis,els.panelAnalysis],
+        learn:[els.tabLearning,els.panelLearning]
+      };
       for(const [k,[btn,pan]] of Object.entries(map)){ const on = (k===key); btn.setAttribute('aria-selected',on); pan.classList.toggle('hidden',!on); }
     }
     els.tabBudget.onclick = ()=>selectTab('budget');
     els.tabTx.onclick = ()=>selectTab('tx');
+    els.tabAnalysis.onclick = ()=>selectTab('analysis');
     els.tabLearning.onclick = ()=>{ selectTab('learn'); renderLearnList(); };
 
     // Initial load

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <div class="tabs" role="tablist">
       <button class="tab" role="tab" id="tab-budget" aria-selected="true">Budget</button>
       <button class="tab" role="tab" id="tab-transactions" aria-selected="false">Transactions</button>
+      <button class="tab" role="tab" id="tab-analysis" aria-selected="false">Analysis</button>
       <button class="tab" role="tab" id="tab-learning" aria-selected="false">Prediction Map</button>
     </div>
 
@@ -124,6 +125,23 @@
       </div>
     </section>
 
+    <section id="panel-analysis" role="tabpanel" class="hidden">
+      <div class="two-col-analysis">
+        <div class="card">
+          <h2>Analysis Options</h2>
+          <div class="content">
+            <!-- Analysis options will be added here -->
+          </div>
+        </div>
+        <div class="card">
+          <h2>Analysis Chart</h2>
+          <div class="content">
+            <canvas id="analysis-chart"></canvas>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section id="panel-learning" role="tabpanel" class="hidden">
       <div class="card">
         <h2>Description → Category Map (auto‑learning)</h2>
@@ -210,6 +228,7 @@
     </div>
   </dialog>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="app/js/app.js"></script>
 </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,9 @@ A small gap now separates the category selector from the Add button for clearer 
 
 Each transaction row now begins with a row number. Prices are bold, match the standard font size, and sit to the left of the edit/delete icons with extra spacing for clearer separation.
 
+### Analysis Tab
+An **Analysis** tab is now available after the Transactions tab. It includes a menu card and a chart area powered by Chart.js for upcoming insights.
+
 ### Transaction Editing
 Each monthly transaction entry includes an edit icon so existing records can be updated.
 


### PR DESCRIPTION
## Summary
- add Analysis tab with empty menu and chart placeholders
- scaffold Chart.js and layout for future analysis tools
- wire up tab logic and document new tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac25b625b8832f9aa5f01e1b876b88