### PR TITLE
Use secondary colour for action icons

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -88,7 +88,7 @@
 
     /* Icon buttons for actions */
     .actions{display:flex;gap:6px}
-    button.icon-btn{padding:0;width:32px;height:32px;border-radius:50%;background:#1e40af;border:0;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;color:#fff}
+    button.icon-btn{padding:0;width:32px;height:32px;border-radius:50%;background:var(--sub);border:0;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;color:#fff}
     button.icon-btn svg{width:16px;height:16px}
 
     /* Fit transaction list card within viewport */

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ You can now add a new budget month or switch between months using the inline con
 
 ### Action Icons
 Edit and delete actions across the app now use circular icon buttons for a cleaner look.
+The icons now adopt the secondary theme colour instead of blue for consistency.
 
 ### Themed Dialogs
 Alerts, confirmations and information messages now appear in a styled pop‑up dialog that matches the app's theme. Any attempt to delete a record prompts for confirmation.


### PR DESCRIPTION
## Summary
- Style edit and delete icon buttons with secondary theme colour
- Document button colour change in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac282bb990832f9b047ec6e96d3d60