### PR TITLE
Alphabetize analysis options and default to budget spread bar chart

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -844,7 +844,7 @@
         els.analysisMonth.value = months.includes(prev) ? prev : currentMonthKey;
         const prevType = els.analysisChartType.value;
         els.analysisChartType.innerHTML = `<option value="pie">Pie Chart</option><option value="bar">Bar Chart</option>`;
-        els.analysisChartType.value = ['pie','bar'].includes(prevType) ? prevType : 'pie';
+        els.analysisChartType.value = ['pie','bar'].includes(prevType) ? prevType : 'bar';
       }else{
         els.analysisMonthRow.classList.add('hidden');
         const prevType = els.analysisChartType.value;

--- a/index.html
+++ b/index.html
@@ -135,8 +135,8 @@
             <div class="row">
               <label>Analysis
                 <select id="analysis-select">
+                  <option value="budget-spread" selected>Budget Spread</option>
                   <option value="monthly-spend">Monthly Spend</option>
-                  <option value="budget-spread">Budget Spread</option>
                 </select>
               </label>
             </div>
@@ -149,7 +149,7 @@
               <label>Chart Style
                 <select id="analysis-chart-type">
                   <option value="line">Line Chart</option>
-                  <option value="bar">Vertical Bar Chart</option>
+                  <option value="bar" selected>Vertical Bar Chart</option>
                 </select>
               </label>
             </div>

--- a/readme.md
+++ b/readme.md
@@ -45,9 +45,7 @@ A small gap now separates the category selector from the Add button for clearer 
 Each transaction row now begins with a row number. Prices are bold, match the standard font size, and sit to the left of the edit/delete icons with extra spacing for clearer separation.
 
 ### Analysis Tab
-An **Analysis** tab is now available after the Transactions tab. It includes a **Monthly Spend** option that charts each month's total spend. Use the **Chart Style** selector to switch between a line chart and a vertical bar chart.
-
-The tab also offers a **Budget Spread** option. Choose a month and see category group distributions as percentages. Planned and actual charts appear side by side as pie charts, or compare them in a combined bar chart where budgeted and actual amounts use different colours.
+An **Analysis** tab is now available after the Transactions tab. It provides **Budget Spread** and **Monthly Spend** options (listed alphabetically) to explore your data. The tab now defaults to the **Budget Spread** displayed as a bar chart. Use the **Chart Style** selector to switch between available chart types for the chosen analysis.
 
 ### Transaction Editing
 Each monthly transaction entry includes an edit icon so existing records can be updated.


### PR DESCRIPTION
## Summary
- Display Budget Spread before Monthly Spend in the Analysis selector and show Vertical Bar Chart by default
- Default Budget Spread chart type to bar when Analysis tab is opened
- Clarify Analysis tab documentation with new default and alphabetical listing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac5c29a1fc832fb5de51c712b3d7af