### PR TITLE
Fix analysis chart month selection

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -881,8 +881,9 @@
         });
       }else if(opt === 'budget-spread'){
         const mk = els.analysisMonth.value || currentMonthKey;
-        const m = Store.getMonth(mk) || Model.emptyMonth();
-        const totals = Model.totals(m);
+        // Fetch the selected month's data rather than the currently open month
+        const monthForChart = Utils.clone(Store.getMonth(mk) || Model.emptyMonth());
+        const totals = Model.totals(monthForChart);
         const labels = Object.keys(totals.groups).sort();
         const planned = labels.map(l=>totals.groups[l]?.budget || 0);
         const actual = labels.map(l=>totals.groups[l]?.actual || 0);

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,8 @@ Each transaction row now begins with a row number. Prices are bold, match the st
 ### Analysis Tab
 An **Analysis** tab is now available after the Transactions tab. It provides **Budget Spread** and **Monthly Spend** options (listed alphabetically) to explore your data. The tab now defaults to the **Budget Spread** displayed as a bar chart. Use the **Chart Style** selector to switch between available chart types for the chosen analysis.
 
+Selecting a different month in the Analysis tab now shows both planned and actual spending for that specific month instead of always using the current month.
+
 ### Transaction Editing
 Each monthly transaction entry includes an edit icon so existing records can be updated.
 


### PR DESCRIPTION
## Summary
- Ensure Analysis tab uses the selected month data for chart calculations
- Document that the Analysis tab now shows planned and actual for the chosen month

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac63abdf50832fa0c8e040d4491a36