### PR TITLE
Ensure Add Transaction form submits correctly

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -368,6 +368,7 @@
       txDesc: document.getElementById('tx-desc'),
       txAmt: document.getElementById('tx-amt'),
       txCat: document.getElementById('tx-cat'),
+      txForm: document.getElementById('tx-form'),
       txSearch: document.getElementById('tx-search'),
       txFilterCat: document.getElementById('tx-filter-cat'),
       addTx: document.getElementById('add-tx'),
@@ -700,18 +701,9 @@
       els.txDesc.focus();
     };
 
-    els.addTx.onclick = handleAddTx;
-
-    [els.txDate, els.txDesc, els.txAmt, els.txCat].forEach(el=>{
-      el.addEventListener('keydown', (e)=>{
-        if(e.key === 'Enter'){
-          if(el === els.txDesc && descSuggestions.length){
-            e.preventDefault();
-            return;
-          }
-          handleAddTx();
-        }
-      });
+    els.txForm.addEventListener('submit', (e)=>{
+      e.preventDefault();
+      handleAddTx();
     });
 
     els.txSearch.oninput = ()=>renderTransactions(Store.getMonth(currentMonthKey));

--- a/index.html
+++ b/index.html
@@ -115,19 +115,21 @@
         <div class="card">
           <h2>Add Transaction</h2>
           <div class="content">
-            <div class="row">
-              <input id="tx-date" type="date" />
-              <input id="tx-desc" placeholder="Description (e.g. Waitrose)" />
-              <input id="tx-amt" type="number" step="0.01" placeholder="Amount (positive = spend)" />
-              <select id="tx-cat"></select>
-            </div>
-            <div id="desc-tooltip" class="tooltip hidden"></div>
-            </br>
-            <div class="row">
-              <button class="primary" id="add-tx">Add</button>
-              <span id="predict-hint" class="badge">Prediction: –</span>
-              <span id="desc-predict-hint" class="badge">Desc: –</span>
-            </div>
+            <form id="tx-form">
+              <div class="row">
+                <input id="tx-date" type="date" />
+                <input id="tx-desc" placeholder="Description (e.g. Waitrose)" />
+                <input id="tx-amt" type="number" step="0.01" placeholder="Amount (positive = spend)" />
+                <select id="tx-cat"></select>
+              </div>
+              <div id="desc-tooltip" class="tooltip hidden"></div>
+              <br />
+              <div class="row">
+                <button class="primary" id="add-tx" type="submit">Add</button>
+                <span id="predict-hint" class="badge">Prediction: –</span>
+                <span id="desc-predict-hint" class="badge">Desc: –</span>
+              </div>
+            </form>
           </div>
         </div>
       </div>

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Categories are global across months—add or edit a category once and it will ap
 As you type a transaction description, the app looks up your past entries that are stored in your browser's local storage. Only unique descriptions are kept. A tooltip beneath the field now spans the full width and lists up to four matches. Use the up and down keys to highlight an option and press <kbd>Enter</kbd> or click to choose one; the description will auto‑fill.
 
 ### Add Transaction Shortcuts
-The add transaction form now requires a date, description and amount before a transaction can be added. Pressing <kbd>Enter</kbd> in any field triggers the add action, and focus returns to the description field to speed up entry of multiple transactions.
+The add transaction form now requires a date, description and amount before a transaction can be added. Pressing <kbd>Enter</kbd> in any field triggers the add action, and focus returns to the description field to speed up entry of multiple transactions. The form now reliably adds a transaction when clicking the **Add** button or pressing <kbd>Enter</kbd> after typing the amount.
 
 ## Tests
 Run `npm test` to verify the project is set up correctly.


### PR DESCRIPTION
## Summary
- Wrap Add Transaction inputs in a form and submit handler
- Trigger transaction creation on form submit instead of per-field keydown
- Document reliable Add button and Enter key behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9214f168832fb6626e6be870b045