### PR TITLE
Add calendar pop-up for quick reference

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -107,3 +107,7 @@
     .calendar-table{width:100%;border-collapse:collapse}
     .calendar-table th,.calendar-table td{border:1px solid var(--border);width:14.28%;height:80px;padding:4px;text-align:right}
     .calendar-table th{background:var(--muted)}
+    #calendar-dialog .dialog-content{width:700px;max-width:90vw}
+    .calendar-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
+    .calendar-header button{background:var(--muted);border:1px solid var(--border);border-radius:4px;padding:4px 8px;cursor:pointer}
+    .calendar-table td.today{background:var(--brand);color:#fff;border-radius:50%}

--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -107,6 +107,8 @@
     .calendar-table{width:100%;border-collapse:collapse}
     .calendar-table th,.calendar-table td{border:1px solid var(--border);width:14.28%;height:80px;padding:4px;text-align:center;vertical-align:middle}
     .calendar-table th{background:var(--muted)}
+    .calendar-table td{position:relative}
+    .calendar-table .day-total{position:absolute;bottom:2px;right:4px;font-size:.75em}
     #calendar-dialog .dialog-content{width:700px;max-width:90vw}
     .calendar-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
     .calendar-header #calendar-month{flex:1;text-align:center}

--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -102,3 +102,8 @@
     .dialog-content{padding:20px;border-top:4px solid var(--brand)}
     dialog.dialog.alert .dialog-content,dialog.dialog.confirm .dialog-content{border-top-color:var(--warn)}
     .dialog-actions{display:flex;justify-content:flex-end;gap:10px;margin-top:20px}
+
+    /* Calendar */
+    .calendar-table{width:100%;border-collapse:collapse}
+    .calendar-table th,.calendar-table td{border:1px solid var(--border);width:14.28%;height:80px;padding:4px;text-align:right}
+    .calendar-table th{background:var(--muted)}

--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -108,7 +108,7 @@
     .calendar-table th,.calendar-table td{border:1px solid var(--border);width:14.28%;height:80px;padding:4px;text-align:center;vertical-align:middle}
     .calendar-table th{background:var(--muted)}
     .calendar-table td{position:relative}
-    .calendar-table .day-total{position:absolute;bottom:2px;right:4px;font-size:.75em}
+    .calendar-table .day-total{position:absolute;bottom:2px;right:4px;font-size:.75em;color:var(--sub)}
     #calendar-dialog .dialog-content{width:700px;max-width:90vw}
     .calendar-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
     .calendar-header #calendar-month{flex:1;text-align:center}

--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -105,9 +105,10 @@
 
     /* Calendar */
     .calendar-table{width:100%;border-collapse:collapse}
-    .calendar-table th,.calendar-table td{border:1px solid var(--border);width:14.28%;height:80px;padding:4px;text-align:right}
+    .calendar-table th,.calendar-table td{border:1px solid var(--border);width:14.28%;height:80px;padding:4px;text-align:center;vertical-align:middle}
     .calendar-table th{background:var(--muted)}
     #calendar-dialog .dialog-content{width:700px;max-width:90vw}
     .calendar-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
+    .calendar-header #calendar-month{flex:1;text-align:center}
     .calendar-header button{background:var(--muted);border:1px solid var(--border);border-radius:4px;padding:4px 8px;cursor:pointer}
-    .calendar-table td.today{background:var(--brand);color:#fff;border-radius:50%}
+    .calendar-table td.today{font-weight:bold}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -321,12 +321,16 @@
       importFile: document.getElementById('import-file'),
       importConfirm: document.getElementById('import-confirm'),
       importCancel: document.getElementById('import-cancel'),
+      calendarDialog: document.getElementById('calendar-dialog'),
+      calendarContainer: document.getElementById('calendar-container'),
+      calendarClose: document.getElementById('calendar-close'),
 
       // Tabs
       tabBudget: document.getElementById('tab-budget'),
       tabTx: document.getElementById('tab-transactions'),
       tabAnalysis: document.getElementById('tab-analysis'),
       tabLearning: document.getElementById('tab-learning'),
+      tabCalendar: document.getElementById('tab-calendar'),
       panelBudget: document.getElementById('panel-budget'),
       panelTx: document.getElementById('panel-transactions'),
       panelAnalysis: document.getElementById('panel-analysis'),
@@ -1022,10 +1026,35 @@
     els.tabTx.onclick = ()=>selectTab('tx');
     els.tabAnalysis.onclick = ()=>{ selectTab('analysis'); runAnalysis(); };
     els.tabLearning.onclick = ()=>{ selectTab('learn'); renderLearnList(); };
+    els.tabCalendar.onclick = ()=>{ renderCalendar(); els.calendarDialog.showModal(); };
+    els.calendarClose.onclick = ()=>els.calendarDialog.close();
     els.analysisSelect.onchange = runAnalysis;
     els.analysisChartType.onchange = runAnalysis;
     els.analysisMonth.onchange = runAnalysis;
     els.analysisGroup.onchange = runAnalysis;
+
+    function renderCalendar(date = new Date()){
+      const year = date.getFullYear();
+      const month = date.getMonth();
+      const first = new Date(year, month, 1);
+      const start = first.getDay();
+      const days = new Date(year, month + 1, 0).getDate();
+      const names = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+      let html = '<table class="calendar-table"><thead><tr>';
+      for(const n of names) html += `<th>${n}</th>`;
+      html += '</tr></thead><tbody><tr>';
+      let day = 1;
+      for(let i=0;i<start;i++) html += '<td></td>';
+      for(let i=start;i<7;i++) html += `<td>${day++}</td>`;
+      html += '</tr>';
+      while(day <= days){
+        html += '<tr>';
+        for(let i=0;i<7;i++) html += day<=days?`<td>${day++}</td>`:'<td></td>';
+        html += '</tr>';
+      }
+      html += '</tbody></table>';
+      els.calendarContainer.innerHTML = html;
+    }
 
     // Initial load
     loadMonth(currentMonthKey);

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1046,10 +1046,8 @@
       const m = Store.getMonth(mk) || {transactions:[]};
       const totals = {};
       for(const tx of m.transactions){
-        if(tx.amount < 0){
-          const d = Number(tx.date.slice(8,10));
-          totals[d] = (totals[d]||0) + -tx.amount;
-        }
+        const d = Number(tx.date.slice(8,10));
+        totals[d] = (totals[d]||0) + Math.abs(tx.amount);
       }
       const first = new Date(year, month, 1);
       const start = (first.getDay() + 6) % 7;

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -324,6 +324,9 @@
       calendarDialog: document.getElementById('calendar-dialog'),
       calendarContainer: document.getElementById('calendar-container'),
       calendarClose: document.getElementById('calendar-close'),
+      calendarPrev: document.getElementById('calendar-prev'),
+      calendarNext: document.getElementById('calendar-next'),
+      calendarMonth: document.getElementById('calendar-month'),
 
       // Tabs
       tabBudget: document.getElementById('tab-budget'),
@@ -394,6 +397,7 @@
     let editingTxId = null;
     let analysisChart = null;
     let analysisChartActual = null;
+    let calendarDate = new Date();
     const ICON_EDIT = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5l4 4L7 21H3v-4L16.5 3.5z"/></svg>`;
     const ICON_DELETE = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m5-3h4a1 1 0 0 1 1 1v2H9V4a1 1 0 0 1 1-1z"/></svg>`;
     const ICON_CHEVRONS_DOWN = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="7 13 12 18 17 13"></polyline><polyline points="7 6 12 11 17 6"></polyline></svg>`;
@@ -1026,34 +1030,44 @@
     els.tabTx.onclick = ()=>selectTab('tx');
     els.tabAnalysis.onclick = ()=>{ selectTab('analysis'); runAnalysis(); };
     els.tabLearning.onclick = ()=>{ selectTab('learn'); renderLearnList(); };
-    els.tabCalendar.onclick = ()=>{ renderCalendar(); els.calendarDialog.showModal(); };
+    els.tabCalendar.onclick = ()=>{ calendarDate = new Date(); renderCalendar(); els.calendarDialog.showModal(); };
     els.calendarClose.onclick = ()=>els.calendarDialog.close();
+    els.calendarPrev.onclick = ()=>{ calendarDate.setMonth(calendarDate.getMonth()-1); renderCalendar(); };
+    els.calendarNext.onclick = ()=>{ calendarDate.setMonth(calendarDate.getMonth()+1); renderCalendar(); };
     els.analysisSelect.onchange = runAnalysis;
     els.analysisChartType.onchange = runAnalysis;
     els.analysisMonth.onchange = runAnalysis;
     els.analysisGroup.onchange = runAnalysis;
 
-    function renderCalendar(date = new Date()){
-      const year = date.getFullYear();
-      const month = date.getMonth();
+    function renderCalendar(){
+      const year = calendarDate.getFullYear();
+      const month = calendarDate.getMonth();
       const first = new Date(year, month, 1);
-      const start = first.getDay();
+      const start = (first.getDay() + 6) % 7;
       const days = new Date(year, month + 1, 0).getDate();
-      const names = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+      const names = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+      const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+      els.calendarMonth.textContent = `${monthNames[month]} ${year}`;
+      const today = new Date();
       let html = '<table class="calendar-table"><thead><tr>';
       for(const n of names) html += `<th>${n}</th>`;
       html += '</tr></thead><tbody><tr>';
       let day = 1;
       for(let i=0;i<start;i++) html += '<td></td>';
-      for(let i=start;i<7;i++) html += `<td>${day++}</td>`;
+      for(let i=start;i<7;i++) html += cell(day++);
       html += '</tr>';
       while(day <= days){
         html += '<tr>';
-        for(let i=0;i<7;i++) html += day<=days?`<td>${day++}</td>`:'<td></td>';
+        for(let i=0;i<7;i++) html += day<=days?cell(day++):'<td></td>';
         html += '</tr>';
       }
       html += '</tbody></table>';
       els.calendarContainer.innerHTML = html;
+
+      function cell(d){
+        const isToday = d===today.getDate() && month===today.getMonth() && year===today.getFullYear();
+        return `<td${isToday?' class="today"':''}>${d}</td>`;
+      }
     }
 
     // Initial load

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1042,6 +1042,15 @@
     function renderCalendar(){
       const year = calendarDate.getFullYear();
       const month = calendarDate.getMonth();
+      const mk = Utils.monthKey(calendarDate);
+      const m = Store.getMonth(mk) || {transactions:[]};
+      const totals = {};
+      for(const tx of m.transactions){
+        if(tx.amount < 0){
+          const d = Number(tx.date.slice(8,10));
+          totals[d] = (totals[d]||0) + -tx.amount;
+        }
+      }
       const first = new Date(year, month, 1);
       const start = (first.getDay() + 6) % 7;
       const days = new Date(year, month + 1, 0).getDate();
@@ -1066,7 +1075,9 @@
 
       function cell(d){
         const isToday = d===today.getDate() && month===today.getMonth() && year===today.getFullYear();
-        return `<td${isToday?' class="today"':''}>${d}</td>`;
+        const total = totals[d];
+        const amt = total?`<span class="day-total">${Utils.fmt(total)}</span>`:'';
+        return `<td${isToday?' class="today"':''}>${d}${amt}</td>`;
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -261,6 +261,11 @@
   </dialog>
   <dialog id="calendar-dialog" class="dialog">
     <div class="dialog-content">
+      <div class="calendar-header">
+        <button id="calendar-prev" aria-label="Previous month">&#9664;</button>
+        <div id="calendar-month"></div>
+        <button id="calendar-next" aria-label="Next month">&#9654;</button>
+      </div>
       <div id="calendar-container"></div>
       <div class="dialog-actions">
         <button id="calendar-close" class="primary">Close</button>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       <button class="tab" role="tab" id="tab-transactions" aria-selected="false">Transactions</button>
       <button class="tab" role="tab" id="tab-analysis" aria-selected="false">Analysis</button>
       <button class="tab" role="tab" id="tab-learning" aria-selected="false">Prediction Map</button>
+      <button class="tab" role="tab" id="tab-calendar" aria-selected="false">Calendar</button>
     </div>
 
       <section id="panel-budget" role="tabpanel">
@@ -255,6 +256,14 @@
       <div class="dialog-actions">
         <button id="export-confirm" class="primary">Export</button>
         <button id="export-cancel" class="secondary">Cancel</button>
+      </div>
+    </div>
+  </dialog>
+  <dialog id="calendar-dialog" class="dialog">
+    <div class="dialog-content">
+      <div id="calendar-container"></div>
+      <div class="dialog-actions">
+        <button id="calendar-close" class="primary">Close</button>
       </div>
     </div>
   </dialog>

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ As you type a transaction description, the app looks up your past entries that a
 The add transaction form now requires a date, description and amount before a transaction can be added. Pressing <kbd>Enter</kbd> in any field triggers the add action, and focus returns to the description field to speed up entry of multiple transactions.
 
 ### Calendar
-A **Calendar** tab opens a wide view-only calendar in a pop‑up dialog for quick date reference. The calendar shows the current month name, highlights today's date, starts weeks on Monday, and includes arrows to navigate between months.
+A **Calendar** tab opens a wide view-only calendar in a pop‑up dialog for quick date reference. The calendar shows the current month name, centers all weekday labels and dates, highlights today's date in bold, starts weeks on Monday, and includes arrows to navigate between months.
 
 ## Tests
 Run `npm test` to verify the project is set up correctly.

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ As you type a transaction description, the app looks up your past entries that a
 The add transaction form now requires a date, description and amount before a transaction can be added. Pressing <kbd>Enter</kbd> in any field triggers the add action, and focus returns to the description field to speed up entry of multiple transactions.
 
 ### Calendar
-A **Calendar** tab opens a large view-only calendar in a pop‑up dialog for quick date reference.
+A **Calendar** tab opens a wide view-only calendar in a pop‑up dialog for quick date reference. The calendar shows the current month name, highlights today's date, starts weeks on Monday, and includes arrows to navigate between months.
 
 ## Tests
 Run `npm test` to verify the project is set up correctly.

--- a/readme.md
+++ b/readme.md
@@ -81,5 +81,8 @@ As you type a transaction description, the app looks up your past entries that a
 ### Add Transaction Shortcuts
 The add transaction form now requires a date, description and amount before a transaction can be added. Pressing <kbd>Enter</kbd> in any field triggers the add action, and focus returns to the description field to speed up entry of multiple transactions.
 
+### Calendar
+A **Calendar** tab opens a large view-only calendar in a pop‑up dialog for quick date reference.
+
 ## Tests
 Run `npm test` to verify the project is set up correctly.

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ As you type a transaction description, the app looks up your past entries that a
 The add transaction form now requires a date, description and amount before a transaction can be added. Pressing <kbd>Enter</kbd> in any field triggers the add action, and focus returns to the description field to speed up entry of multiple transactions.
 
 ### Calendar
-A **Calendar** tab opens a wide view-only calendar in a pop‑up dialog for quick date reference. The calendar shows the current month name, centers all weekday labels and dates, highlights today's date in bold, starts weeks on Monday, includes arrows to navigate between months, and shows each day's total spend in the bottom-right corner of its cell.
+A **Calendar** tab opens a wide view-only calendar in a pop‑up dialog for quick date reference. The calendar shows the current month name, centers all weekday labels and dates, highlights today's date in bold, starts weeks on Monday, includes arrows to navigate between months, and shows each day's total transaction amount in the bottom-right corner of its cell using a secondary font color.
 
 ## Tests
 Run `npm test` to verify the project is set up correctly.

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ As you type a transaction description, the app looks up your past entries that a
 The add transaction form now requires a date, description and amount before a transaction can be added. Pressing <kbd>Enter</kbd> in any field triggers the add action, and focus returns to the description field to speed up entry of multiple transactions.
 
 ### Calendar
-A **Calendar** tab opens a wide view-only calendar in a pop‑up dialog for quick date reference. The calendar shows the current month name, centers all weekday labels and dates, highlights today's date in bold, starts weeks on Monday, and includes arrows to navigate between months.
+A **Calendar** tab opens a wide view-only calendar in a pop‑up dialog for quick date reference. The calendar shows the current month name, centers all weekday labels and dates, highlights today's date in bold, starts weeks on Monday, includes arrows to navigate between months, and shows each day's total spend in the bottom-right corner of its cell.
 
 ## Tests
 Run `npm test` to verify the project is set up correctly.


### PR DESCRIPTION
## Summary
- add Calendar tab beside Prediction Map
- show view-only calendar in themed dialog
- document calendar feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac95869b80832fb7469d58bfc483f3