### PR TITLE
feat: highlight transaction rows on hover

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -70,6 +70,7 @@
     .list-item .grow{flex:1}
     .list-item .tx-index{width:24px;color:var(--sub)}
     .list-item .tx-amount{text-align:right;font-weight:bold;font-size:1em;margin-right:16px}
+    #tx-list .list-item:hover{background:var(--muted)}
     .tx-date{padding:8px 10px;background:var(--muted);font-weight:700;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px}
     .tx-date .totals{display:flex;gap:12px;font-weight:400}
     .tx-date .tx-count{margin-left:8px;font-weight:400}

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ The monthly transactions card now leaves a 20px gap from the bottom of the scree
 A small gap now separates the category selector from the Add button for clearer entry.
 
 Each transaction row now begins with a row number. Prices are bold, match the standard font size, and sit to the left of the edit/delete icons with extra spacing for clearer separation.
+Transaction rows highlight on mouse hover for improved readability.
 
 ### Analysis Tab
 An **Analysis** tab is now available after the Transactions tab. It provides **Budget Spread** and **Monthly Spend** options (listed alphabetically) to explore your data. The tab now defaults to the **Budget Spread** displayed as a bar chart. Use the **Chart Style** selector to switch between available chart types for the chosen analysis.


### PR DESCRIPTION
## Summary
- highlight transactions list rows on hover for clearer tracking
- document new hover behavior in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc650c2d8832fb2220c6a1afb777b