### PR TITLE
refactor: streamline month controls

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -21,7 +21,7 @@
     header h1{font-size:18px;margin:0;font-weight:700}
     .pill{background:rgba(255,255,255,.16);padding:6px 10px;border-radius:999px}
 
-    .toolbar{display:flex;flex-wrap:wrap;gap:8px;margin-left:auto;width:480px}
+    .toolbar{display:flex;flex-wrap:wrap;gap:8px;margin-left:auto}
       .toolbar select,.toolbar button,.toolbar input[type="month"]{
         appearance:none;border:1px solid rgba(255,255,255,.5);background:rgba(255,255,255,.15);
         color:#fff;border-radius:8px;padding:6px 10px;backdrop-filter: blur(4px);

--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -21,7 +21,7 @@
     header h1{font-size:18px;margin:0;font-weight:700}
     .pill{background:rgba(255,255,255,.16);padding:6px 10px;border-radius:999px}
 
-    .toolbar{display:flex;flex-wrap:wrap;gap:8px;margin-left:auto}
+    .toolbar{display:flex;flex-wrap:wrap;gap:8px;margin-left:auto;width:480px}
       .toolbar select,.toolbar button,.toolbar input[type="month"]{
         appearance:none;border:1px solid rgba(255,255,255,.5);background:rgba(255,255,255,.15);
         color:#fff;border-radius:8px;padding:6px 10px;backdrop-filter: blur(4px);

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -350,7 +350,6 @@
       leftoverPill: document.getElementById('leftover-pill'),
       monthPicker: document.getElementById('month-picker'),
       newMonth: document.getElementById('new-month'),
-      duplicateMonth: document.getElementById('duplicate-month'),
       openMonth: document.getElementById('open-month'),
       exportBtn: document.getElementById('export-data'),
       exportDialog: document.getElementById('export-dialog'),
@@ -832,7 +831,7 @@
     // Month controls
     els.newMonth.onclick = ()=>{
       const mk = els.monthPicker.value || Utils.monthKey();
-      if(Store.getMonth(mk)) { Dialog.alert('Month already exists. Use Duplicate if needed.'); return; }
+      if(Store.getMonth(mk)) { Dialog.alert('Month already exists. Choose a different month.'); return; }
       const month = Model.template();
       const months = Store.allMonths();
       if(months.length){
@@ -840,12 +839,6 @@
         month.categories = Utils.clone(Store.categories(prev));
       }
       Store.setMonth(mk, month); loadMonth(mk);
-    };
-    els.duplicateMonth.onclick = ()=>{
-      const months = Store.allMonths(); if(months.length<1) return;
-      const prev = months[months.length-1]; const mk = els.monthPicker.value || Utils.monthKey();
-      const dup = Utils.clone(Store.getMonth(prev)); dup.transactions=[]; // carry incomes, not tx
-      Store.setMonth(mk, dup); loadMonth(mk);
     };
     els.openMonth.onchange = (e)=>{ if(e.target.value) loadMonth(e.target.value); };
 

--- a/index.html
+++ b/index.html
@@ -12,20 +12,17 @@
     <h1>Budget for <span id="header-month"></span></h1>
     <span class="pill" id="leftover-pill">Left Over £0.00</span>
 
-    <div class="toolbar">
-      <div class="inline-field">
-        <label for="month-picker">Add Month</label>
-        <input type="month" id="month-picker"/>
-        <button id="new-month" title="Create a new month from template or copy last month">Add</button>
+      <div class="toolbar">
+        <div class="inline-field">
+          <label for="month-picker">Add Month</label>
+          <input type="month" id="month-picker"/>
+          <button id="new-month" title="Create a new month from template or copy last month">Add</button>
+          <label for="open-month">Open Month</label>
+          <select id="open-month"></select>
+        </div>
+        <button id="export-data">Export</button>
+        <button id="import-trans">Import</button>
       </div>
-      <div class="inline-field">
-        <label for="open-month">Open Month</label>
-        <select id="open-month"></select>
-      </div>
-      <button id="duplicate-month">Duplicate Prev</button>
-      <button id="export-data">Export</button>
-      <button id="import-trans">Import</button>
-    </div>
   </header>
 
   <main>

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ The app now starts with no pre-filled categories or incomes. Previously seeded "
 JavaScript files are located in `app/js` and stylesheets in `app/css`.
 
 ### Month Controls
-You can now add a new budget month or switch between months using the inline controls in the header. New months start with a copy of the previous month's categories so each month's budget can evolve independently.
+You can add a new budget month or switch between months using the inline controls in the header. New months start with a copy of the previous month's categories so each month's budget can evolve independently. The previous **Duplicate Prev** button has been removed, and the **Add Month** and **Open Month** controls now appear on a single line for quicker access.
 
 ### Action Icons
 Edit and delete actions across the app now use circular icon buttons for a cleaner look.

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ The app now starts with no pre-filled categories or incomes. Previously seeded "
 JavaScript files are located in `app/js` and stylesheets in `app/css`.
 
 ### Month Controls
-You can add a new budget month or switch between months using the inline controls in the header. New months start with a copy of the previous month's categories so each month's budget can evolve independently. The previous **Duplicate Prev** button has been removed, and the **Add Month** and **Open Month** controls now appear on a single line for quicker access.
+You can add a new budget month or switch between months using the inline controls in the header. New months start with a copy of the previous month's categories so each month's budget can evolve independently. The previous **Duplicate Prev** button has been removed, and the **Add Month** and **Open Month** controls now appear on a single line for quicker access. The toolbar has been widened so these controls remain on one row.
 
 ### Action Icons
 Edit and delete actions across the app now use circular icon buttons for a cleaner look.

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ The app now starts with no pre-filled categories or incomes. Previously seeded "
 JavaScript files are located in `app/js` and stylesheets in `app/css`.
 
 ### Month Controls
-You can add a new budget month or switch between months using the inline controls in the header. New months start with a copy of the previous month's categories so each month's budget can evolve independently. The previous **Duplicate Prev** button has been removed, and the **Add Month** and **Open Month** controls now appear on a single line for quicker access. The toolbar has been widened so these controls remain on one row.
+You can add a new budget month or switch between months using the inline controls in the header. New months start with a copy of the previous month's categories so each month's budget can evolve independently. The previous **Duplicate Prev** button has been removed, and the **Add Month** and **Open Month** controls now appear on a single line for quicker access.
 
 ### Action Icons
 Edit and delete actions across the app now use circular icon buttons for a cleaner look.


### PR DESCRIPTION
## Summary
- remove Duplicate Prev button and logic
- display Add Month and Open Month controls on a single line
- clarify message when new month already exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade8619e88832f9d5bfd4c32505f88