### PR TITLE
Display totals for selected Analysis view

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -413,6 +413,7 @@
       analysisChart: document.getElementById('analysis-chart'),
       analysisChartActual: document.getElementById('analysis-chart-actual'),
       analysisCharts: document.getElementById('analysis-charts'),
+      analysisTotal: document.getElementById('analysis-total'),
       analysisMonthRow: document.getElementById('analysis-month-row'),
       analysisMonth: document.getElementById('analysis-month'),
       analysisGroupRow: document.getElementById('analysis-group-row'),
@@ -1084,6 +1085,7 @@
     const runAnalysis = ()=>{
       const opt = els.analysisSelect.value;
       els.analysisCharts.classList.remove('charts');
+      els.analysisTotal.textContent = '';
       if(opt === 'budget-spread'){
         els.analysisMonthRow.classList.remove('hidden');
         els.analysisGroupRow.classList.add('hidden');
@@ -1140,6 +1142,8 @@
             return g === group;
           }), t=>t.amount);
         });
+        const total = Utils.sum(data);
+        els.analysisTotal.textContent = Utils.fmt(total);
         const label = category ? `${category} Spend` : group ? `${group} Spend` : 'Total Spend';
         analysisChart = new Chart(els.analysisChart.getContext('2d'), {
           type: style === 'bar' ? 'bar' : 'line',
@@ -1166,6 +1170,7 @@
         const actual = labels.map(l=>totals.groups[l]?.actual || 0);
         const plannedTot = Utils.sum(planned);
         const actualTot = Utils.sum(actual);
+        els.analysisTotal.textContent = `Planned ${Utils.fmt(plannedTot)} / Actual ${Utils.fmt(actualTot)}`;
         const plannedPct = planned.map(v=> plannedTot ? (v/plannedTot*100) : 0);
         const actualPct = actual.map(v=> actualTot ? (v/actualTot*100) : 0);
         const palette = ['#0ea5e9','#f43f5e','#10b981','#f59e0b','#8b5cf6','#ec4899','#14b8a6','#f97316','#22c55e','#d946ef'];

--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
           </div>
         </div>
         <div class="card">
-          <h2>Analysis Chart</h2>
+          <h2><span>Analysis Chart</span><span id="analysis-total"></span></h2>
           <div class="content" id="analysis-charts">
             <div>
               <h3 id="analysis-planned-title" class="hidden">Planned</h3>

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ An **Analysis** tab is now available after the Transactions tab. It provides **B
 
 Selecting a different month in the Analysis tab now shows both planned and actual spending for that specific month instead of always using the current month.
 The Monthly Spend view can now be filtered by group using the Group selector, which defaults to showing all groups. A Category selector beneath it lets you drill down to a single category.
+The Analysis Chart header now displays the total for the selected view, showing both planned and actual totals for Budget Spread or the combined spend for Monthly Spend.
 
 ### Transaction Editing
 Each monthly transaction entry includes an edit icon so existing records can be updated.


### PR DESCRIPTION
## Summary
- Show total of selected data in Analysis Chart header
- Calculate totals for Monthly Spend and Budget Spread analyses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b08e8d0700832f8bd279c912abfb53