### PR TITLE
refactor: modularize storage and chart logic

### DIFF
--- a/app/js/chart.js
+++ b/app/js/chart.js
@@ -1,0 +1,75 @@
+export function monthlySpendChart(ctx, labels, data, style, label){
+  return new Chart(ctx, {
+    type: style === 'bar' ? 'bar' : 'line',
+    data: {
+      labels,
+      datasets: [{
+        label,
+        data,
+        borderColor: '#0ea5e9',
+        backgroundColor: '#0ea5e9',
+        tension: 0.2,
+        fill: false
+      }]
+    },
+    options: { scales: { y: { beginAtZero: true } } }
+  });
+}
+
+export function budgetSpreadCharts(planCtx, actualCtx, labels, planned, actual, style, colors, plannedPct, actualPct, fmt){
+  const percentPlugin = {
+    id:'pct',
+    afterDatasetsDraw(chart){
+      const {ctx} = chart;
+      const dataset = chart.data.datasets[0];
+      chart.getDatasetMeta(0).data.forEach((arc,i)=>{
+        const val = dataset.data[i]||0;
+        const pos = arc.tooltipPosition();
+        ctx.save();
+        ctx.fillStyle='#fff';
+        ctx.font='14px system-ui';
+        ctx.textAlign='center';
+        ctx.textBaseline='middle';
+        ctx.fillText(`${val.toFixed(1)}%`, pos.x, pos.y);
+        ctx.restore();
+      });
+    }
+  };
+  const pieOpts = {
+    plugins:{
+      tooltip:{callbacks:{label:c=>`${c.label}: ${c.parsed.toFixed(1)}%`}}
+    }
+  };
+  const barOpts = {
+    plugins:{tooltip:{callbacks:{label:c=>`${c.dataset.label}: ${fmt(c.parsed.y)}`}}},
+    scales:{y:{beginAtZero:true,ticks:{callback:v=>fmt(v)}}}
+  };
+  let chart, actualChart=null;
+  if(style === 'pie'){
+    chart = new Chart(planCtx, {
+      type:'pie',
+      data:{labels,datasets:[{label:'Planned %', data: plannedPct, backgroundColor: colors}]},
+      options: pieOpts,
+      plugins:[percentPlugin]
+    });
+    actualChart = new Chart(actualCtx, {
+      type:'pie',
+      data:{labels,datasets:[{label:'Actual %', data: actualPct, backgroundColor: colors}]},
+      options: pieOpts,
+      plugins:[percentPlugin]
+    });
+  }else{
+    chart = new Chart(planCtx, {
+      type:'bar',
+      data:{
+        labels,
+        datasets:[
+          {label:'Planned', data: planned, backgroundColor:'#0ea5e9'},
+          {label:'Actual', data: actual, backgroundColor:'#f43f5e'}
+        ]
+      },
+      options: barOpts
+    });
+  }
+  return {chart, actualChart};
+}

--- a/app/js/storage.js
+++ b/app/js/storage.js
@@ -1,0 +1,92 @@
+import { Utils } from './utils.js';
+
+export const Store = (()=>{
+  const KEY = 'budget.local.v1';
+  const load = ()=>{
+    try{
+      return JSON.parse(localStorage.getItem(KEY)) || {version:1, months:{}, mapping:{exact:{}, tokens:{}}, descMap:{exact:{}, tokens:{}}, ui:{collapsed:{}}, descList:[], notes:[]};
+    }
+    catch{
+      return {version:1, months:{}, mapping:{exact:{}, tokens:{}}, descMap:{exact:{}, tokens:{}}, ui:{collapsed:{}}, descList:[], notes:[]};
+    }
+  };
+  const save = (state)=>localStorage.setItem(KEY, JSON.stringify(state));
+  const state = load();
+  for(const m of Object.values(state.months||{})){
+    m.categories = m.categories || {};
+  }
+  state.notes = state.notes || [];
+  if(state.categories){
+    for(const m of Object.values(state.months)){
+      m.categories = {...Utils.clone(state.categories), ...m.categories};
+    }
+    delete state.categories;
+    save(state);
+  }
+  const getMonth = (mk)=> state.months[mk];
+  const setMonth = (mk, data)=>{ state.months[mk]=data; save(state); };
+  const allMonths = ()=> Object.keys(state.months).sort();
+  const categories = (mk)=> state.months[mk]?.categories || {};
+  const mapping = ()=> state.mapping;
+  const setMapping = (m)=>{ state.mapping = m; save(state); };
+  const descMap = ()=> state.descMap || (state.descMap={exact:{},tokens:{}});
+  const setDescMap = (m)=>{ state.descMap = m; save(state); };
+  const descList = ()=> state.descList || (state.descList=[]);
+  const setDescList = (list)=>{ state.descList = list; save(state); };
+  const exportData = (kind, mk)=>{
+    if(kind==='transactions'){
+      const m = state.months[mk];
+      return m ? (m.transactions||[]) : [];
+    }
+    if(kind==='categories'){
+      const m = state.months[mk];
+      return {categories: m ? (m.categories||{}) : {}};
+    }
+    if(kind==='prediction'){
+      return {mapping: state.mapping, descMap: state.descMap, descList: state.descList||[]};
+    }
+    return {version:state.version, months: state.months, mapping: state.mapping, descMap: state.descMap, descList: state.descList||[]};
+  };
+  const importData = (json)=>{
+    const incoming = typeof json === 'string' ? JSON.parse(json) : json;
+    if(!incoming || !incoming.months) return;
+    state.version = incoming.version || state.version;
+    state.mapping.exact = {...state.mapping.exact, ...(incoming.mapping?.exact||{})};
+    for(const [k,v] of Object.entries(incoming.mapping?.tokens||{})){
+      const cur = state.mapping.tokens[k] || {};
+      for(const [cat,cnt] of Object.entries(v)) cur[cat] = (cur[cat]||0)+cnt;
+      state.mapping.tokens[k] = cur;
+    }
+    state.descMap = state.descMap || {exact:{},tokens:{}};
+    state.descMap.exact = {...state.descMap.exact, ...(incoming.descMap?.exact||{})};
+    for(const [k,v] of Object.entries(incoming.descMap?.tokens||{})){
+      const cur = state.descMap.tokens[k] || {};
+      for(const [desc,cnt] of Object.entries(v)) cur[desc] = (cur[desc]||0)+cnt;
+      state.descMap.tokens[k] = cur;
+    }
+    const inList = incoming.descList || [];
+    const curList = descList();
+    for(const d of inList){
+      if(!curList.some(x=>x.toLowerCase()===d.toLowerCase())) curList.push(d);
+    }
+    state.descList = curList;
+    if(incoming.categories){
+      for(const m of Object.values(incoming.months)){
+        m.categories = {...incoming.categories, ...(m.categories||{})};
+      }
+    }
+    for(const [mk,month] of Object.entries(incoming.months)){
+      month.categories = month.categories || {};
+      state.months[mk]=month;
+    }
+    save(state);
+  };
+  const collapsedFor = (mk)=>{ state.ui = state.ui || {collapsed:{}}; state.ui.collapsed = state.ui.collapsed || {}; state.ui.collapsed[mk] = state.ui.collapsed[mk] || {}; return state.ui.collapsed[mk]; };
+  const isCollapsed = (mk,g)=> !!collapsedFor(mk)[g];
+  const setCollapsed = (mk,g,val)=>{ collapsedFor(mk)[g]=!!val; save(state); };
+  const toggleCollapsed = (mk,g)=>{ setCollapsed(mk,g,!isCollapsed(mk,g)); };
+  const setAllCollapsed = (mk, groups, val)=>{ const obj = collapsedFor(mk); (groups||[]).forEach(g=>obj[g]=!!val); save(state); };
+  const notes = ()=> state.notes || [];
+  const setNotes = (list)=>{ state.notes = list; save(state); };
+  return {state,getMonth,setMonth,allMonths,categories,mapping,setMapping,descMap,setDescMap,descList,setDescList,exportData,importData,collapsedFor,isCollapsed,setCollapsed,toggleCollapsed,setAllCollapsed,notes,setNotes};
+})();

--- a/app/js/utils.js
+++ b/app/js/utils.js
@@ -1,0 +1,71 @@
+export const Utils = (()=>{
+  const fmt = (n)=>`£${(n||0).toFixed(2)}`;
+  const setText = (el,n)=>{ el.textContent = fmt(n); el.classList.toggle('danger', n<0); };
+  const id = () => Math.random().toString(36).slice(2,9);
+  const monthKey = (d)=>{
+    if(typeof d === 'string') return d;
+    const dt = d || new Date();
+    const m = String(dt.getMonth()+1).padStart(2,'0');
+    return `${dt.getFullYear()}-${m}`;
+  };
+  const groupBy = (arr, fn)=>arr.reduce((a,x)=>{const k=fn(x);(a[k]=a[k]||[]).push(x);return a;},{});
+  const sum = (arr, fn=(x)=>x)=>arr.reduce((a,x)=>a+fn(x),0);
+  const clone = (o)=>JSON.parse(JSON.stringify(o));
+  const parseCSV = (text, map, hasHeader=true, invert=false)=>{
+    const lines = text.trim().split(/\r?\n/).filter(l=>l);
+    if(hasHeader) lines.shift();
+    let idx = {date:0, desc:1, category:2, amount:3};
+    if(map){
+      idx = {};
+      for(const [k,v] of Object.entries(map)){
+        idx[k] = (v==='' || v===null) ? -1 : Number(v);
+      }
+    }
+    const splitLine = (line)=>{
+      const cols = [];
+      let cur = '';
+      let inQuotes = false;
+      for(let i=0;i<line.length;i++){
+        const ch = line[i];
+        if(ch === '"'){
+          if(inQuotes && line[i+1] === '"'){ cur+='"'; i++; }
+          else inQuotes = !inQuotes;
+        }else if(ch===',' && !inQuotes){
+          cols.push(cur.trim());
+          cur='';
+        }else{
+          cur+=ch;
+        }
+      }
+      cols.push(cur.trim());
+      return cols.map(s=>s.replace(/^"|"$/g,'').replace(/""/g,'"'));
+    };
+    return lines.map(line=>{
+      const cols = splitLine(line);
+      const dRaw = idx.date>=0 ? cols[idx.date]||'' : '';
+      const desc = idx.desc>=0 ? cols[idx.desc]||'' : '';
+      const category = idx.category>=0 ? cols[idx.category]||'' : '';
+      let aRaw = idx.amount>=0 ? cols[idx.amount]||'' : '';
+      if(idx.amount>=0 && cols.length>Math.max(idx.amount+1,4)){
+        aRaw = cols.slice(idx.amount).join('');
+      }
+      let date = '';
+      if(dRaw){
+        const [dd,mm,yyyy] = dRaw.split(/[\/]/);
+        if(yyyy && mm && dd) date = `${yyyy}-${mm}-${dd}`;
+      }
+      let amount = Number(aRaw.replace(/[^0-9.-]/g,'')) || 0;
+      if(invert) amount = -amount;
+      return {date,desc,category,amount};
+    });
+  };
+  const toCSV = (txs)=>[
+    'Date,Description,Category,Amount',
+    ...txs.map(t=>{
+      const [y,m,d] = (t.date||'').split('-');
+      const date = d?`${d}/${m}/${y}`:'';
+      return [date,t.desc,t.category,`£${Number(t.amount||0).toFixed(2)}`].join(',');
+    })
+  ].join('\n');
+  return {fmt,id,monthKey,groupBy,sum,clone,parseCSV,toCSV,setText};
+})();

--- a/index.html
+++ b/index.html
@@ -320,6 +320,6 @@
   </dialog>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="app/js/app.js"></script>
+  <script type="module" src="app/js/app.js"></script>
 </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,12 @@ The app now starts with no pre-filled categories or incomes. Previously seeded "
 
 ## File Structure
 JavaScript files are located in `app/js` and stylesheets in `app/css`.
+The JavaScript code is split into modules:
+
+- `utils.js` – shared helper functions
+- `storage.js` – local storage persistence
+- `chart.js` – chart rendering helpers
+- `app.js` – main application logic
 
 ### Month Controls
 You can add a new budget month or switch between months using the inline controls in the header. New months start with a copy of the previous month's categories so each month's budget can evolve independently. The previous **Duplicate Prev** button has been removed, and the **Add Month** and **Open Month** controls now appear on a single line for quicker access.


### PR DESCRIPTION
## Summary
- move utilities, storage, and chart rendering into dedicated ES modules
- load main app as a module and use chart helpers for analysis views
- document modular JS structure in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0aa9bd1e8832f824905d4485c679f