### PR TITLE
feat: add year filter for monthly spend

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -416,6 +416,8 @@
       analysisTotal: document.getElementById('analysis-total'),
       analysisMonthRow: document.getElementById('analysis-month-row'),
       analysisMonth: document.getElementById('analysis-month'),
+      analysisYearRow: document.getElementById('analysis-year-row'),
+      analysisYear: document.getElementById('analysis-year'),
       analysisGroupRow: document.getElementById('analysis-group-row'),
       analysisGroup: document.getElementById('analysis-group'),
       analysisCategoryRow: document.getElementById('analysis-category-row'),
@@ -1088,6 +1090,7 @@
       els.analysisTotal.textContent = '';
       if(opt === 'budget-spread'){
         els.analysisMonthRow.classList.remove('hidden');
+        els.analysisYearRow.classList.add('hidden');
         els.analysisGroupRow.classList.add('hidden');
         els.analysisCategoryRow.classList.add('hidden');
         const months = Store.allMonths();
@@ -1100,8 +1103,15 @@
         els.analysisChartType.value = ['pie','bar'].includes(prevType) ? prevType : 'bar';
       }else if(opt === 'monthly-spend'){
         els.analysisMonthRow.classList.add('hidden');
+        els.analysisYearRow.classList.remove('hidden');
         els.analysisGroupRow.classList.remove('hidden');
         els.analysisCategoryRow.classList.remove('hidden');
+        const monthsAll = Store.allMonths();
+        const years = [...new Set(monthsAll.map(m=>m.slice(0,4)))].sort();
+        const prevYear = els.analysisYear.value;
+        const yearOpts = ['<option value="">All</option>', ...years.map(y=>`<option value="${y}">${y}</option>`)];
+        els.analysisYear.innerHTML = yearOpts.join('');
+        els.analysisYear.value = years.includes(prevYear) ? prevYear : '';
         const catsCur = Store.categories(currentMonthKey);
         const groups = [...new Set(Object.values(catsCur).map(x=>x.group||'Other'))].sort();
         const prevGroup = els.analysisGroup.value;
@@ -1126,7 +1136,8 @@
       els.analysisActualTitle.classList.add('hidden');
       els.analysisChartActual.classList.add('hidden');
       if(opt === 'monthly-spend'){
-        const months = Store.allMonths();
+        const yearSel = els.analysisYear.value;
+        const months = Store.allMonths().filter(m=>!yearSel || m.startsWith(yearSel));
         const labels = months;
         const group = els.analysisGroup.value;
         const category = els.analysisCategory.value;
@@ -1259,6 +1270,7 @@
     els.analysisSelect.onchange = runAnalysis;
     els.analysisChartType.onchange = runAnalysis;
     els.analysisMonth.onchange = runAnalysis;
+    els.analysisYear.onchange = runAnalysis;
     els.analysisGroup.onchange = runAnalysis;
     els.analysisCategory.onchange = runAnalysis;
 

--- a/index.html
+++ b/index.html
@@ -155,6 +155,11 @@
                 <select id="analysis-month"></select>
               </label>
             </div>
+            <div class="row hidden" id="analysis-year-row">
+              <label>Year
+                <select id="analysis-year"></select>
+              </label>
+            </div>
             <div class="row hidden" id="analysis-group-row">
               <label>Group
                 <select id="analysis-group"></select>

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Transaction rows highlight on mouse hover for improved readability.
 An **Analysis** tab is now available after the Transactions tab. It provides **Budget Spread** and **Monthly Spend** options (listed alphabetically) to explore your data. The tab now defaults to the **Budget Spread** displayed as a bar chart. Use the **Chart Style** selector to switch between available chart types for the chosen analysis.
 
 Selecting a different month in the Analysis tab now shows both planned and actual spending for that specific month instead of always using the current month.
-The Monthly Spend view can now be filtered by group using the Group selector, which defaults to showing all groups. A Category selector beneath it lets you drill down to a single category.
+The Monthly Spend view can now be filtered by year using the Year selector, which lists each available data year along with an All option. A Group selector lets you narrow by group, defaulting to all groups, and a Category selector beneath it lets you drill down to a single category.
 The Analysis Chart header now displays the total for the selected view, showing both planned and actual totals for Budget Spread or the combined spend for Monthly Spend.
 
 ### Transaction Editing


### PR DESCRIPTION
## Summary
- add Year selector to Monthly Spend analysis with per-year and All options
- wire runAnalysis to filter months by selected year
- document Year filter in analysis section of README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ed588ae4832fbfcf8357651b6e60