### PR TITLE
Add Money In analysis view

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1101,6 +1101,29 @@
         const prevType = els.analysisChartType.value;
         els.analysisChartType.innerHTML = `<option value="pie">Pie Chart</option><option value="bar">Bar Chart</option>`;
         els.analysisChartType.value = ['pie','bar'].includes(prevType) ? prevType : 'bar';
+      }else if(opt === 'money-in'){
+        els.analysisMonthRow.classList.add('hidden');
+        els.analysisYearRow.classList.remove('hidden');
+        els.analysisGroupRow.classList.remove('hidden');
+        els.analysisCategoryRow.classList.remove('hidden');
+        const monthsAll = Store.allMonths();
+        const years = [...new Set(monthsAll.map(m=>m.slice(0,4)))].sort();
+        const prevYear = els.analysisYear.value;
+        const yearOpts = ['<option value="">All</option>', ...years.map(y=>`<option value="${y}">${y}</option>`)];
+        els.analysisYear.innerHTML = yearOpts.join('');
+        els.analysisYear.value = years.includes(prevYear) ? prevYear : '';
+        const incomesCur = (Store.getMonth(currentMonthKey) || {}).incomes || [];
+        const groupOpts = ['<option value="">All</option>'];
+        els.analysisGroup.innerHTML = groupOpts.join('');
+        els.analysisGroup.value = '';
+        const prevCat = els.analysisCategory.value;
+        const catList = incomesCur.map(x=>x.name).sort();
+        const catOpts = ['<option value="">All</option>', ...catList.map(c=>`<option value="${c}">${c}</option>`)];
+        els.analysisCategory.innerHTML = catOpts.join('');
+        els.analysisCategory.value = catList.includes(prevCat) ? prevCat : '';
+        const prevType = els.analysisChartType.value;
+        els.analysisChartType.innerHTML = `<option value="line">Line Chart</option><option value="bar">Vertical Bar Chart</option>`;
+        els.analysisChartType.value = ['line','bar'].includes(prevType) ? prevType : 'line';
       }else if(opt === 'monthly-spend'){
         els.analysisMonthRow.classList.add('hidden');
         els.analysisYearRow.classList.remove('hidden');
@@ -1165,6 +1188,34 @@
               data,
               borderColor: '#0ea5e9',
               backgroundColor: '#0ea5e9',
+              tension: 0.2,
+              fill: false
+            }]
+          },
+          options: { scales: { y: { beginAtZero: true } } }
+        });
+      }else if(opt === 'money-in'){
+        const yearSel = els.analysisYear.value;
+        const months = Store.allMonths().filter(m=>!yearSel || m.startsWith(yearSel));
+        const labels = months;
+        const category = els.analysisCategory.value;
+        const data = months.map(mk=>{
+          const m = Store.getMonth(mk) || {incomes:[]};
+          const incomes = m.incomes || [];
+          return Utils.sum(incomes.filter(i=>!category || i.name===category), i=>i.amount);
+        });
+        const total = Utils.sum(data);
+        els.analysisTotal.textContent = Utils.fmt(total);
+        const label = category ? `${category} Income` : 'Total Income';
+        analysisChart = new Chart(els.analysisChart.getContext('2d'), {
+          type: style === 'bar' ? 'bar' : 'line',
+          data: {
+            labels,
+            datasets: [{
+              label,
+              data,
+              borderColor: '#10b981',
+              backgroundColor: '#10b981',
               tension: 0.2,
               fill: false
             }]

--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
               <label>Analysis
                 <select id="analysis-select">
                   <option value="budget-spread" selected>Budget Spread</option>
+                  <option value="money-in">Money In</option>
                   <option value="monthly-spend">Monthly Spend</option>
                 </select>
               </label>

--- a/readme.md
+++ b/readme.md
@@ -54,10 +54,10 @@ Each transaction row now begins with a row number. Prices are bold, match the st
 Transaction rows highlight on mouse hover for improved readability.
 
 ### Analysis Tab
-An **Analysis** tab is now available after the Transactions tab. It provides **Budget Spread** and **Monthly Spend** options (listed alphabetically) to explore your data. The tab now defaults to the **Budget Spread** displayed as a bar chart. Use the **Chart Style** selector to switch between available chart types for the chosen analysis.
+An **Analysis** tab is now available after the Transactions tab. It provides **Budget Spread**, **Money In** and **Monthly Spend** options (listed alphabetically) to explore your data. The tab now defaults to the **Budget Spread** displayed as a bar chart. Use the **Chart Style** selector to switch between available chart types for the chosen analysis.
 
 Selecting a different month in the Analysis tab now shows both planned and actual spending for that specific month instead of always using the current month.
-The Monthly Spend view can now be filtered by year using the Year selector, which lists each available data year along with an All option. A Group selector lets you narrow by group, defaulting to all groups, and a Category selector beneath it lets you drill down to a single category.
+The Monthly Spend view can now be filtered by year using the Year selector, which lists each available data year along with an All option. A Group selector lets you narrow by group, defaulting to all groups, and a Category selector beneath it lets you drill down to a single category. The Money In view offers the same filters, letting you explore income over time or by source.
 The Analysis Chart header now displays the total for the selected view, showing both planned and actual totals for Budget Spread or the combined spend for Monthly Spend.
 
 ### Transaction Editing


### PR DESCRIPTION
## Summary
- add Money In to Analysis tab alongside Budget Spread and Monthly Spend
- chart incomes over time with same filters as monthly spending
- document new Money In option and shared filters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b40d1618f8832f93091bcf3bcc77b8