### PR TITLE
Include all income sources in Money In analysis

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1112,12 +1112,12 @@
         const yearOpts = ['<option value="">All</option>', ...years.map(y=>`<option value="${y}">${y}</option>`)];
         els.analysisYear.innerHTML = yearOpts.join('');
         els.analysisYear.value = years.includes(prevYear) ? prevYear : '';
-        const incomesCur = (Store.getMonth(currentMonthKey) || {}).incomes || [];
         const groupOpts = ['<option value="">All</option>'];
         els.analysisGroup.innerHTML = groupOpts.join('');
         els.analysisGroup.value = '';
         const prevCat = els.analysisCategory.value;
-        const catList = incomesCur.map(x=>x.name).sort();
+        const incomesAll = monthsAll.flatMap(mk => (Store.getMonth(mk)?.incomes || []));
+        const catList = [...new Set(incomesAll.map(x=>x.name))].sort();
         const catOpts = ['<option value="">All</option>', ...catList.map(c=>`<option value="${c}">${c}</option>`)];
         els.analysisCategory.innerHTML = catOpts.join('');
         els.analysisCategory.value = catList.includes(prevCat) ? prevCat : '';

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1116,8 +1116,12 @@
         els.analysisGroup.innerHTML = groupOpts.join('');
         els.analysisGroup.value = '';
         const prevCat = els.analysisCategory.value;
-        const incomesAll = monthsAll.flatMap(mk => (Store.getMonth(mk)?.incomes || []));
-        const catList = [...new Set(incomesAll.map(x=>x.name))].sort();
+        const allMonthsData = Store.exportData().months || {};
+        const catSet = new Set();
+        for(const m of Object.values(allMonthsData)){
+          (m.incomes||[]).forEach(i=>catSet.add(i.name));
+        }
+        const catList = [...catSet].sort();
         const catOpts = ['<option value="">All</option>', ...catList.map(c=>`<option value="${c}">${c}</option>`)];
         els.analysisCategory.innerHTML = catOpts.join('');
         els.analysisCategory.value = catList.includes(prevCat) ? prevCat : '';

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ An **Analysis** tab is now available after the Transactions tab. It provides **B
 
 Selecting a different month in the Analysis tab now shows both planned and actual spending for that specific month instead of always using the current month.
 The Monthly Spend view can now be filtered by year using the Year selector, which lists each available data year along with an All option. A Group selector lets you narrow by group, defaulting to all groups, and a Category selector beneath it lets you drill down to a single category. The Money In view offers the same filters, letting you explore income over time or by source.
-The Money In view now pulls income labels from every month so the source selector and chart include all categories.
+The Money In view now pulls income labels from every stored month so the source selector and chart include all categories across your history.
 The Analysis Chart header now displays the total for the selected view, showing both planned and actual totals for Budget Spread or the combined spend for Monthly Spend.
 
 ### Transaction Editing

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ An **Analysis** tab is now available after the Transactions tab. It provides **B
 
 Selecting a different month in the Analysis tab now shows both planned and actual spending for that specific month instead of always using the current month.
 The Monthly Spend view can now be filtered by year using the Year selector, which lists each available data year along with an All option. A Group selector lets you narrow by group, defaulting to all groups, and a Category selector beneath it lets you drill down to a single category. The Money In view offers the same filters, letting you explore income over time or by source.
+The Money In view now pulls income labels from every month so the source selector and chart include all categories.
 The Analysis Chart header now displays the total for the selected view, showing both planned and actual totals for Budget Spread or the combined spend for Monthly Spend.
 
 ### Transaction Editing


### PR DESCRIPTION
## Summary
- Ensure Money In analysis lists all income categories by scanning every month.
- Document that Money In selector now includes all income sources.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b49f5c9050832f8e7a1eb32e1b4d7e