### PR TITLE
Use date picker for budget month selection

### DIFF
--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -702,7 +702,7 @@ private struct MonthPickerField: View {
         return lower...upper
     }
 
-    private static func extendedRange(_ range: ClosedRange<Int>, toInclude year: Int) -> ClosedRange<Int> {
+    fileprivate static func extendedRange(_ range: ClosedRange<Int>, toInclude year: Int) -> ClosedRange<Int> {
         var lower = range.lowerBound
         var upper = range.upperBound
         if year <= lower {


### PR DESCRIPTION
## Summary
- replace the export/import month text input with a reusable MonthPickerField backed by SwiftUI's DatePicker
- normalize selected dates to the yyyy-MM format and keep the bound month string in sync with external changes
- update invalid month alerts to reflect the selector-based workflow

## Testing
- npm install
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d0805fde08832f8b4d710fb80174f6