### PR TITLE
Add confirmation dialogs for iOS deletions

### DIFF
--- a/ios/HomeBudgetingApp/Views/Components/AppDialog.swift
+++ b/ios/HomeBudgetingApp/Views/Components/AppDialog.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct AppDialog: Identifiable {
+    enum Style {
+        case info
+        case error
+        case confirm(destructive: Bool)
+    }
+
+    let id = UUID()
+    let style: Style
+    let title: String
+    let message: String?
+    let confirmTitle: String
+    let cancelTitle: String?
+    let onConfirm: (() -> Void)?
+
+    init(style: Style, title: String, message: String? = nil, confirmTitle: String = "OK", cancelTitle: String? = nil, onConfirm: (() -> Void)? = nil) {
+        self.style = style
+        self.title = title
+        self.message = message
+        self.confirmTitle = confirmTitle
+        self.cancelTitle = cancelTitle
+        self.onConfirm = onConfirm
+    }
+}
+
+extension AppDialog {
+    static func info(title: String, message: String? = nil, buttonTitle: String = "OK", onDismiss: (() -> Void)? = nil) -> AppDialog {
+        AppDialog(style: .info, title: title, message: message, confirmTitle: buttonTitle, onConfirm: onDismiss)
+    }
+
+    static func error(title: String, message: String? = nil, buttonTitle: String = "OK", onDismiss: (() -> Void)? = nil) -> AppDialog {
+        AppDialog(style: .error, title: title, message: message, confirmTitle: buttonTitle, onConfirm: onDismiss)
+    }
+
+    static func confirm(title: String, message: String? = nil, confirmTitle: String = "Confirm", cancelTitle: String = "Cancel", destructive: Bool = false, onConfirm: (() -> Void)? = nil) -> AppDialog {
+        AppDialog(style: .confirm(destructive: destructive), title: title, message: message, confirmTitle: confirmTitle, cancelTitle: cancelTitle, onConfirm: onConfirm)
+    }
+}
+
+extension AppDialog {
+    fileprivate func makeAlert() -> Alert {
+        let messageText = message.map(Text.init)
+        switch style {
+        case .info, .error:
+            return Alert(
+                title: Text(title),
+                message: messageText,
+                dismissButton: .default(Text(confirmTitle)) {
+                    onConfirm?()
+                }
+            )
+        case .confirm(let destructive):
+            let primary: Alert.Button = destructive
+                ? .destructive(Text(confirmTitle)) { onConfirm?() }
+                : .default(Text(confirmTitle)) { onConfirm?() }
+            let cancelButton: Alert.Button = {
+                if let cancelTitle {
+                    return .cancel(Text(cancelTitle))
+                } else {
+                    return .cancel()
+                }
+            }()
+            return Alert(
+                title: Text(title),
+                message: messageText,
+                primaryButton: primary,
+                secondaryButton: cancelButton
+            )
+        }
+    }
+}
+
+extension View {
+    func appDialog(_ dialog: Binding<AppDialog?>) -> some View {
+        alert(item: dialog) { dialog in
+            dialog.makeAlert()
+        }
+    }
+}

--- a/ios/HomeBudgetingApp/Views/Notes/NotesScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Notes/NotesScreen.swift
@@ -6,6 +6,7 @@ struct NotesScreen: View {
     @State private var editingNote: BudgetNote?
     @State private var noteTitle: String = ""
     @State private var noteBody: String = ""
+    @State private var activeDialog: AppDialog?
 
     var body: some View {
         NavigationStack {
@@ -33,7 +34,15 @@ struct NotesScreen: View {
                         }
                         .tint(.primary)
                         .swipeActions(edge: .trailing) {
-                            Button(role: .destructive) { viewModel.deleteNote(id: note.id) } label: {
+                            Button(role: .destructive) {
+                                activeDialog = AppDialog.confirm(
+                                    title: "Delete Note",
+                                    message: "Are you sure you want to delete this note?",
+                                    confirmTitle: "Delete",
+                                    destructive: true,
+                                    onConfirm: { viewModel.deleteNote(id: note.id) }
+                                )
+                            } label: {
                                 Label("Delete", systemImage: "trash")
                             }
                         }
@@ -81,6 +90,7 @@ struct NotesScreen: View {
                     }
                 }
             }
+            .appDialog($activeDialog)
         }
     }
 

--- a/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
@@ -4,6 +4,7 @@ struct TransactionsScreen: View {
     @EnvironmentObject private var viewModel: BudgetViewModel
     @State private var showEditor = false
     @State private var editingTransaction: BudgetTransaction?
+    @State private var activeDialog: AppDialog?
 
     private var transactionsState: TransactionsUiState { viewModel.uiState.transactions }
 
@@ -18,7 +19,16 @@ struct TransactionsScreen: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if !transactionsState.groups.isEmpty {
-                        Button("Clear") { viewModel.deleteAllTransactions() }
+                        Button("Clear") {
+                            let monthName = viewModel.uiState.selectedMonthKey ?? "this month"
+                            activeDialog = AppDialog.confirm(
+                                title: "Clear Transactions",
+                                message: "Are you sure you want to delete all transactions for \(monthName)?",
+                                confirmTitle: "Clear",
+                                destructive: true,
+                                onConfirm: { viewModel.deleteAllTransactions() }
+                            )
+                        }
                             .tint(.red)
                     }
                 }
@@ -37,6 +47,7 @@ struct TransactionsScreen: View {
                     }
                 )
             }
+            .appDialog($activeDialog)
         }
     }
 
@@ -90,7 +101,15 @@ struct TransactionsScreen: View {
                     }
                     .tint(.primary)
                     .swipeActions(edge: .trailing) {
-                        Button(role: .destructive) { viewModel.deleteTransaction(id: tx.id) } label: {
+                        Button(role: .destructive) {
+                            activeDialog = AppDialog.confirm(
+                                title: "Delete Transaction",
+                                message: "Delete \(tx.desc) for \(currency(tx.amount))?",
+                                confirmTitle: "Delete",
+                                destructive: true,
+                                onConfirm: { viewModel.deleteTransaction(id: tx.id) }
+                            )
+                        } label: {
                             Label("Delete", systemImage: "trash")
                         }
                     }


### PR DESCRIPTION
## Summary
- add a reusable AppDialog helper so alerts share the same styling and behavior
- prompt for confirmation before deleting future months, incomes, categories, and reuse AppDialog for import/export alerts
- require confirmation before clearing all transactions, deleting individual transactions, or removing notes

## Testing
- swift build *(fails: SwiftUI is unavailable in the Linux build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d08dbb2fa4832f890635d61bd933b8