### PR TITLE
Enable dark mode on iOS

### DIFF
--- a/ios/AppHost/Info.plist
+++ b/ios/AppHost/Info.plist
@@ -40,7 +40,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
+        <key>UIUserInterfaceStyle</key>
+        <string>Automatic</string>
 </dict>
 </plist>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -33,7 +33,7 @@ targets:
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         UILaunchStoryboardName: LaunchScreen
-        UIUserInterfaceStyle: Light
+        UIUserInterfaceStyle: Automatic
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationLandscapeLeft

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,8 @@ swift build
 
 Open the **Budget** tab to access matching import/export options for transactions (JSON or CSV), categories, the prediction learning data, or a complete backup compatible with the web experience.
 
+The iOS interface now follows your system appearance, automatically switching between light and dark mode.
+
 ## Usage
 Open `web-app/index.html` in a browser to track your income and expenses for each month. The app now uses 95% of your screen width to provide a wider workspace.
 


### PR DESCRIPTION
## Summary
- allow the iOS host target to follow the system appearance by switching UIUserInterfaceStyle to Automatic
- document the new dark mode behavior for the iOS app in the README

## Testing
- npm install
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d08ecd2288832f80a61f43e3127759