### PR TITLE
Show transaction counts per day in iOS

### DIFF
--- a/ios/HomeBudgetingApp/Domain/BudgetCalculations.swift
+++ b/ios/HomeBudgetingApp/Domain/BudgetCalculations.swift
@@ -106,6 +106,7 @@ struct TransactionGroup: Identifiable {
     let date: Date
     let label: String
     let transactions: [BudgetTransaction]
+    let transactionCount: Int
     let dayTotal: Double
     let runningTotal: Double
     let startIndex: Int
@@ -147,6 +148,7 @@ func groupTransactions(month: BudgetMonth?, filter: TransactionFilter) -> ([Tran
                 date: date,
                 label: label,
                 transactions: list,
+                transactionCount: list.count,
                 dayTotal: dayTotal,
                 runningTotal: runningTotal,
                 startIndex: runningIndex

--- a/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
@@ -77,7 +77,7 @@ struct TransactionsScreen: View {
 
     private var transactionSections: some View {
         ForEach(transactionsState.groups) { group in
-            Section(header: Text("\(group.label)")) {
+            Section(header: sectionHeader(for: group)) {
                 ForEach(group.transactions) { tx in
                     Button(action: {
                         editingTransaction = tx
@@ -126,6 +126,20 @@ struct TransactionsScreen: View {
                 }.font(.caption)
             }
         }
+    }
+
+    private func sectionHeader(for group: TransactionGroup) -> some View {
+        HStack {
+            Text(group.label)
+            Spacer()
+            Text(transactionCountDescription(for: group.transactionCount))
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func transactionCountDescription(for count: Int) -> String {
+        count == 1 ? "1 transaction" : "\(count) transactions"
     }
 
     private func currency(_ value: Double) -> String {


### PR DESCRIPTION
## Summary
- add a stored transactionCount on TransactionGroup when grouping transactions for the selected month
- display the per-day transaction count in the Transactions screen section headers

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d09b5acdd4832f8a78c4c8685c8d49