### PR TITLE
Move month selector to floating header and tighten delete guard

### DIFF
--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -64,11 +64,7 @@ struct BudgetScreen: View {
                 Text(key).tag(key)
             }
         } label: {
-            Label {
-                Text(selectedMonthLabel)
-            } icon: {
-                Image(systemName: "calendar")
-            }
+            Label("Month", systemImage: "calendar")
         }
         .pickerStyle(.menu)
         .disabled(viewModel.uiState.monthKeys.isEmpty)

--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -61,7 +61,6 @@ struct BudgetScreen: View {
     private var floatingMonthSelector: some View {
         GeometryReader { proxy in
             HStack {
-                Spacer(minLength: 0)
                 Picker(selection: selectedMonthBinding) {
                     ForEach(viewModel.uiState.monthKeys, id: \.self) { key in
                         Text(key).tag(key)
@@ -96,12 +95,23 @@ struct BudgetScreen: View {
                 .disabled(viewModel.uiState.monthKeys.isEmpty)
                 .accessibilityLabel("Month")
                 .accessibilityValue(Text(selectedMonthLabel))
+                Spacer(minLength: 0)
             }
             .padding(.horizontal)
-            .padding(.top, 8)
-            .padding(.bottom, 4)
+            .padding(.vertical, 6)
         }
         .frame(height: 76)
+    }
+
+    @ViewBuilder
+    private var monthSectionHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            floatingMonthSelector
+            Text("Months")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .textCase(nil)
     }
 
     private enum Field: Hashable {
@@ -123,9 +133,6 @@ struct BudgetScreen: View {
             }
             .listStyle(.insetGrouped)
             .navigationTitle("Budget")
-            .safeAreaInset(edge: .top) {
-                floatingMonthSelector
-            }
             .toolbar {
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()
@@ -198,10 +205,7 @@ struct BudgetScreen: View {
             }
             .disabled(deletableFutureMonthKey == nil)
         } header: {
-            Text("Months")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .textCase(nil)
+            monthSectionHeader
         }
     }
 

--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -103,17 +103,6 @@ struct BudgetScreen: View {
         .frame(height: 76)
     }
 
-    @ViewBuilder
-    private var monthSectionHeader: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            floatingMonthSelector
-            Text("Months")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .textCase(nil)
-    }
-
     private enum Field: Hashable {
         case incomeName
         case incomeAmount
@@ -133,7 +122,11 @@ struct BudgetScreen: View {
             }
             .listStyle(.insetGrouped)
             .navigationTitle("Budget")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .principal) {
+                    floatingMonthSelector
+                }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()
                     Button("Done") { focusedField = nil }
@@ -205,8 +198,11 @@ struct BudgetScreen: View {
             }
             .disabled(deletableFutureMonthKey == nil)
         } header: {
-            monthSectionHeader
+            Text("Months")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
+        .textCase(nil)
     }
 
     private var summarySection: some View {

--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -41,6 +41,41 @@ struct BudgetScreen: View {
         return candidate
     }
 
+    private var selectedMonthValue: String {
+        viewModel.uiState.selectedMonthKey
+            ?? viewModel.uiState.monthKeys.last
+            ?? ""
+    }
+
+    private var selectedMonthLabel: String {
+        selectedMonthValue.isEmpty ? "Select Month" : selectedMonthValue
+    }
+
+    private var selectedMonthBinding: Binding<String> {
+        Binding(
+            get: { selectedMonthValue },
+            set: { viewModel.selectMonth($0) }
+        )
+    }
+
+    private var monthPickerToolbar: some View {
+        Picker(selection: selectedMonthBinding) {
+            ForEach(viewModel.uiState.monthKeys, id: \.self) { key in
+                Text(key).tag(key)
+            }
+        } label: {
+            Label {
+                Text(selectedMonthLabel)
+            } icon: {
+                Image(systemName: "calendar")
+            }
+        }
+        .pickerStyle(.menu)
+        .disabled(viewModel.uiState.monthKeys.isEmpty)
+        .accessibilityLabel("Selected Month")
+        .accessibilityValue(Text(selectedMonthLabel))
+    }
+
     private enum Field: Hashable {
         case incomeName
         case incomeAmount
@@ -61,6 +96,9 @@ struct BudgetScreen: View {
             .listStyle(.insetGrouped)
             .navigationTitle("Budget")
             .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    monthPickerToolbar
+                }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()
                     Button("Done") { focusedField = nil }
@@ -132,22 +170,10 @@ struct BudgetScreen: View {
             }
             .disabled(deletableFutureMonthKey == nil)
         } header: {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Selected Month")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Picker("Selected Month", selection: Binding(
-                    get: { viewModel.uiState.selectedMonthKey ?? "" },
-                    set: { viewModel.selectMonth($0) }
-                )) {
-                    ForEach(viewModel.uiState.monthKeys, id: \.self) { key in
-                        Text(key).tag(key)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
-            }
-            .textCase(nil)
+            Text("Months")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .textCase(nil)
         }
     }
 

--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -58,22 +58,50 @@ struct BudgetScreen: View {
         )
     }
 
-    private var monthPickerToolbar: some View {
-        Picker(selection: selectedMonthBinding) {
-            ForEach(viewModel.uiState.monthKeys, id: \.self) { key in
-                Text(key).tag(key)
+    private var floatingMonthSelector: some View {
+        GeometryReader { proxy in
+            HStack {
+                Spacer(minLength: 0)
+                Picker(selection: selectedMonthBinding) {
+                    ForEach(viewModel.uiState.monthKeys, id: \.self) { key in
+                        Text(key).tag(key)
+                    }
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "calendar")
+                            .font(.headline)
+                            .foregroundStyle(.tint)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Month")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(selectedMonthLabel)
+                                .font(.callout)
+                                .fontWeight(.semibold)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.85)
+                        }
+                        Spacer(minLength: 4)
+                        Image(systemName: "chevron.down")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 14)
+                    .frame(width: max(proxy.size.width / 2, 0), alignment: .leading)
+                    .background(.thinMaterial, in: Capsule())
+                    .shadow(color: Color.black.opacity(0.12), radius: 6, x: 0, y: 4)
+                }
+                .pickerStyle(.menu)
+                .disabled(viewModel.uiState.monthKeys.isEmpty)
+                .accessibilityLabel("Month")
+                .accessibilityValue(Text(selectedMonthLabel))
             }
-        } label: {
-            Image(systemName: "calendar")
-                .font(.headline)
-                .foregroundStyle(.tint)
-                .frame(width: 36, height: 36)
-                .contentShape(Rectangle())
+            .padding(.horizontal)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
         }
-        .pickerStyle(.menu)
-        .disabled(viewModel.uiState.monthKeys.isEmpty)
-        .accessibilityLabel("Selected Month")
-        .accessibilityValue(Text(selectedMonthLabel))
+        .frame(height: 76)
     }
 
     private enum Field: Hashable {
@@ -95,10 +123,10 @@ struct BudgetScreen: View {
             }
             .listStyle(.insetGrouped)
             .navigationTitle("Budget")
+            .safeAreaInset(edge: .top) {
+                floatingMonthSelector
+            }
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    monthPickerToolbar
-                }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()
                     Button("Done") { focusedField = nil }

--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -64,7 +64,11 @@ struct BudgetScreen: View {
                 Text(key).tag(key)
             }
         } label: {
-            Label("Month", systemImage: "calendar")
+            Image(systemName: "calendar")
+                .font(.headline)
+                .foregroundStyle(.tint)
+                .frame(width: 36, height: 36)
+                .contentShape(Rectangle())
         }
         .pickerStyle(.menu)
         .disabled(viewModel.uiState.monthKeys.isEmpty)


### PR DESCRIPTION
## Summary
- move the budget month picker into the section header so it stays visible while create/delete controls remain in the list body
- disable the delete control when the immediate next calendar month is unavailable and reuse the calculated month key in the confirmation prompt
- tighten the view-model guard so only the next calendar month can be removed and centralize month-format helpers

## Testing
- npm test
- swift build *(fails on Linux because SwiftUI is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d10e22a5ec832f882221c74247271c