### PR TITLE
Update gitignore for Apple tooling and artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,37 @@ ios/Pods/
 ios/*.xcworkspace
 ios/**/*.xcuserdata/
 ios/**/*.xcuserstate
+
+# Xcode user settings
+*.xcuserstate
+xcuserdata/
+
+# Build products
+build/
+DerivedData/
+
+# Workspace settings
+*.xcworkspace
+
+# iOS / macOS specific
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# Swift Package Manager
+.build/
+
+# CocoaPods
+Pods/
+
+# Carthage
+Carthage/Build/
+
+# Fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# General
+.DS_Store


### PR DESCRIPTION
## Summary
- add ignores for Xcode user settings, build products, and workspace files
- exclude common iOS/macOS distribution and debugging archives
- ignore Swift Package Manager, CocoaPods, Carthage, and Fastlane outputs

## Testing
- npm install
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d113436cac832fa96a5761a2599f10