### PR TITLE
Add month picker below category filter on Transactions tab

### DIFF
--- a/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
@@ -12,6 +12,7 @@ struct TransactionsScreen: View {
         NavigationStack {
             List {
                 filterSection
+                monthSection
                 transactionSections
             }
             .listStyle(.insetGrouped)
@@ -71,6 +72,32 @@ struct TransactionsScreen: View {
                 Text("Total")
                 Spacer()
                 Text(currency(transactionsState.total)).bold()
+            }
+        }
+    }
+
+    private var monthSection: some View {
+        Section(header: Text("Month")) {
+            if viewModel.uiState.monthKeys.isEmpty {
+                Text("No months available")
+                    .foregroundStyle(.secondary)
+            } else {
+                Picker("Selected Month", selection: Binding(
+                    get: {
+                        viewModel.uiState.selectedMonthKey
+                            ?? viewModel.uiState.monthKeys.last
+                            ?? ""
+                    },
+                    set: { newValue in
+                        guard !newValue.isEmpty else { return }
+                        viewModel.selectMonth(newValue)
+                    }
+                )) {
+                    ForEach(viewModel.uiState.monthKeys, id: \.self) { key in
+                        Text(key).tag(key)
+                    }
+                }
+                .pickerStyle(.menu)
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a dedicated month selection section to the transactions screen and place it below the category filter
- show a placeholder message when no month data is available

## Testing
- npm test
- swift build *(fails on Linux because SwiftUI is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d115008744832fb37faea66bc76ee3