### PR TITLE
Reorder budget screen sections

### DIFF
--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -49,10 +49,10 @@ struct BudgetScreen: View {
     var body: some View {
         NavigationStack {
             List {
-                monthSection
                 summarySection
                 incomesSection
                 categoriesSection
+                monthSection
                 dataSection
             }
             .listStyle(.insetGrouped)


### PR DESCRIPTION
## Summary
- move the month management section below the categories list in the budget tab

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d13593fd60832fa6bf82dc0f239cd6