### PR TITLE
Add ± toggle to iOS numeric keypad

### DIFF
--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -212,7 +212,7 @@ struct BudgetScreen: View {
                 TextField("Name", text: $incomeName)
                     .focused($focusedField, equals: .incomeName)
                 TextField("Amount", text: $incomeAmount)
-                    .keyboardType(.decimalPad)
+                    .signedDecimalKeyboard(text: $incomeAmount)
                     .focused($focusedField, equals: .incomeAmount)
                 Button(editingIncomeId == nil ? "Add Income" : "Save Income") {
                     if let amount = Double(incomeAmount) {
@@ -318,7 +318,7 @@ struct BudgetScreen: View {
                 TextField("Group", text: $categoryGroup)
                     .focused($focusedField, equals: .categoryGroup)
                 TextField("Budget", text: $categoryBudget)
-                    .keyboardType(.decimalPad)
+                    .signedDecimalKeyboard(text: $categoryBudget)
                     .focused($focusedField, equals: .categoryBudget)
                 Button(editingCategoryOriginalName == nil ? "Add Category" : "Save Category") {
                     if let budget = Double(categoryBudget) {

--- a/ios/HomeBudgetingApp/Views/Components/SignedDecimalKeyboardModifier.swift
+++ b/ios/HomeBudgetingApp/Views/Components/SignedDecimalKeyboardModifier.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct SignedDecimalKeyboardModifier: ViewModifier {
+    @Binding var text: String
+
+    func body(content: Content) -> some View {
+        content
+            .keyboardType(.decimalPad)
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button(action: toggleSign) {
+                        Text("±")
+                            .font(.headline)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                    }
+                    .accessibilityLabel(Text("Toggle sign"))
+                }
+            }
+    }
+
+    private func toggleSign() {
+        var trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isNegative = trimmed.hasPrefix("-")
+        trimmed = trimmed.replacingOccurrences(of: "-", with: "")
+
+        if isNegative {
+            text = trimmed
+        } else {
+            text = trimmed.isEmpty ? "-" : "-\(trimmed)"
+        }
+    }
+}
+
+extension View {
+    func signedDecimalKeyboard(text: Binding<String>) -> some View {
+        modifier(SignedDecimalKeyboardModifier(text: text))
+    }
+}

--- a/ios/HomeBudgetingApp/Views/Prediction/PredictionScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Prediction/PredictionScreen.swift
@@ -17,7 +17,7 @@ struct PredictionScreen: View {
                             predictedCategory = ""
                         }
                     TextField("Amount", text: $amountInput)
-                        .keyboardType(.decimalPad)
+                        .signedDecimalKeyboard(text: $amountInput)
                     if !predictedCategory.isEmpty {
                         Text("Prediction: \(predictedCategory)")
                             .font(.headline)

--- a/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
@@ -205,7 +205,7 @@ private struct TransactionEditor: View {
                         .disableAutocorrection(true)
                     TextField("Description", text: $desc)
                     TextField("Amount", text: $amount)
-                        .keyboardType(.decimalPad)
+                        .signedDecimalKeyboard(text: $amount)
                     Picker("Category", selection: $category) {
                         Text("Uncategorised").tag("")
                         ForEach(categories, id: \.self) { value in

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,8 @@ Open the **Budget** tab to access matching import/export options for transaction
 
 The iOS interface now follows your system appearance, automatically switching between light and dark mode.
 
+Amount fields now include a ± toggle on the numeric keypad so you can enter refunds or other negative values directly from the keyboard.
+
 ## Usage
 Open `web-app/index.html` in a browser to track your income and expenses for each month. The app now uses 95% of your screen width to provide a wider workspace.
 


### PR DESCRIPTION
## Summary
- add a reusable SwiftUI modifier that adds a ± toggle to decimal text fields
- apply the modifier to income, category, transaction, and prediction amount inputs so negative values are easy to enter
- document the new keypad behavior in the iOS section of the README

## Testing
- npm install
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d135f43fa0832fa90d65f64c8e1afa