### PR TITLE
Add date picker to transaction editor and switch date format to dd-MM-yyyy

### DIFF
--- a/ios/HomeBudgetingApp/ViewModels/BudgetViewModel.swift
+++ b/ios/HomeBudgetingApp/ViewModels/BudgetViewModel.swift
@@ -681,11 +681,14 @@ public final class BudgetViewModel: ObservableObject {
 
     private func makeCsv(for transactions: [BudgetTransaction]) -> String {
         var lines = ["Date,Description,Category,Amount"]
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_GB")
+        formatter.dateFormat = "dd/MM/yyyy"
         for tx in transactions {
-            let parts = tx.date.split(separator: "-")
             let date: String
-            if parts.count == 3 {
-                date = "\(parts[2])/\(parts[1])/\(parts[0])"
+            if let parsed = parseDate(tx.date) {
+                date = formatter.string(from: parsed)
             } else {
                 date = ""
             }
@@ -750,13 +753,16 @@ public final class BudgetViewModel: ObservableObject {
 
     private func normalizeDate(_ raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        let parts = trimmed.split(whereSeparator: { $0 == "/" || $0 == "-" })
-        if parts.count == 3 {
-            let day = parts[0]
-            let month = parts[1]
-            let year = parts[2]
-            if year.count == 4 {
-                return "\(year)-\(month)-\(day)"
+        guard !trimmed.isEmpty else { return "" }
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_GB")
+        let acceptedFormats = ["dd/MM/yyyy", "dd-MM-yyyy", "yyyy-MM-dd", "yyyy/MM/dd"]
+        for format in acceptedFormats {
+            formatter.dateFormat = format
+            if let date = formatter.date(from: trimmed) {
+                formatter.dateFormat = "dd-MM-yyyy"
+                return formatter.string(from: date)
             }
         }
         return ""


### PR DESCRIPTION
## Summary
- replace the date text field in the transaction editor with a DatePicker so users get the native selector when tapping the date
- format saved dates from the picker and parse existing transaction dates when editing
- switch transaction date strings to the dd-MM-yyyy format with fallbacks across the calendar, exports, and predictors

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d1489c3a70832f84b2e5ab6509d725