### PR TITLE
Fix SwiftUI onChange deprecation warnings

### DIFF
--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -118,8 +118,8 @@ struct BudgetScreen: View {
             .appDialog($activeDialog)
         }
         .onAppear { syncMonthInputs() }
-        .onChange(of: viewModel.uiState.selectedMonthKey) { _ in syncMonthInputs() }
-        .onChange(of: viewModel.uiState.monthKeys) { _ in syncMonthInputs() }
+        .onChange(of: viewModel.uiState.selectedMonthKey) { _, _ in syncMonthInputs() }
+        .onChange(of: viewModel.uiState.monthKeys) { _, _ in syncMonthInputs() }
     }
 
     private var monthSection: some View {


### PR DESCRIPTION
## Summary
- update the budget screen to use the iOS 17 onChange closure signature so deprecation warnings are resolved

## Testing
- npm install
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d15cbb1efc832f8b135e4d5acd1ef2