### PR TITLE
Fix transactions toolbar spacing

### DIFF
--- a/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
@@ -14,15 +14,6 @@ struct TransactionsScreen: View {
         NavigationStack {
             ScrollViewReader { proxy in
                 List {
-                    GeometryReader { geometry in
-                        Color.clear
-                            .preference(key: ScrollOffsetPreferenceKey.self, value: geometry.frame(in: .named("scroll")).minY)
-                    }
-                    .frame(height: 0)
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets())
-                    
                     Section {
                         HStack {
                             Text("Total")
@@ -33,8 +24,17 @@ struct TransactionsScreen: View {
                                 .fontWeight(.semibold)
                         }
                         .padding(.vertical, 8)
+                        .background(
+                            GeometryReader { geometry in
+                                Color.clear
+                                    .preference(
+                                        key: ScrollOffsetPreferenceKey.self,
+                                        value: geometry.frame(in: .named("scroll")).minY
+                                    )
+                            }
+                        )
                     }
-                    
+
                     transactionSections
                 }
                 .listStyle(.insetGrouped)


### PR DESCRIPTION
## Summary
- remove the invisible list row used for scroll tracking on the transactions screen
- attach the scroll offset measurement to the total section to close the gap beneath the toolbar

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d15d2fe8d4832f8ae5cd5334c6d78c