### PR TITLE
Adopt SwiftUI onChange updates for iOS 17

### DIFF
--- a/ios/HomeBudgetingApp/Views/Analysis/AnalysisScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Analysis/AnalysisScreen.swift
@@ -171,7 +171,7 @@ private struct BudgetSpreadView: View {
         }
         .padding()
         .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
-        .onChange(of: style) { newStyle in
+        .onChange(of: style) { _, newStyle in
             highlightedCategory = nil
             if newStyle != .donut {
                 selectedSeries = .planned
@@ -280,7 +280,7 @@ private struct BudgetSpreadView: View {
                 currencyFormatter: currency
             )
         }
-        .onChange(of: selectedSeries) { _ in
+        .onChange(of: selectedSeries) {
             highlightedCategory = nil
         }
     }

--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -118,8 +118,8 @@ struct BudgetScreen: View {
             .appDialog($activeDialog)
         }
         .onAppear { syncMonthInputs() }
-        .onChange(of: viewModel.uiState.selectedMonthKey) { _ in syncMonthInputs() }
-        .onChange(of: viewModel.uiState.monthKeys) { _ in syncMonthInputs() }
+        .onChange(of: viewModel.uiState.selectedMonthKey) { syncMonthInputs() }
+        .onChange(of: viewModel.uiState.monthKeys) { syncMonthInputs() }
     }
 
     private var monthSection: some View {
@@ -709,7 +709,7 @@ private struct ExportOptionsView: View {
                         .disabled(kind.requiresMonth && month.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .onChange(of: kind) { newKind in
+            .onChange(of: kind) { _, newKind in
                 if !newKind.supportsCSV {
                     format = .json
                 }
@@ -772,7 +772,7 @@ private struct ImportOptionsView: View {
                         .disabled(kind.requiresMonth && month.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .onChange(of: kind) { newKind in
+            .onChange(of: kind) { _, newKind in
                 if !newKind.supportsCSV {
                     format = .json
                 }
@@ -845,7 +845,7 @@ private struct MonthPickerField: View {
             .presentationDetents([.height(320), .medium])
             .presentationDragIndicator(.visible)
         }
-        .onChange(of: month) { newValue in
+        .onChange(of: month) { _, newValue in
             guard let parsed = MonthPickerField.formatter.date(from: newValue) else { return }
             cachedDate = parsed
             expandYearRange(toInclude: parsed)

--- a/ios/HomeBudgetingApp/Views/Calendar/CalendarScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Calendar/CalendarScreen.swift
@@ -81,7 +81,7 @@ struct CalendarScreen: View {
         .sheet(item: $activeDay) { day in
             CalendarDayDetailView(day: day, monthTitle: viewModel.uiState.calendar.title)
         }
-        .onChange(of: selectedMonthKey) { _ in
+        .onChange(of: selectedMonthKey) {
             activeDay = nil
         }
     }

--- a/ios/HomeBudgetingApp/Views/Prediction/PredictionScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Prediction/PredictionScreen.swift
@@ -12,7 +12,7 @@ struct PredictionScreen: View {
             Form {
                 Section(header: Text("Predict Category")) {
                     TextField("Description", text: $descriptionInput)
-                        .onChange(of: descriptionInput) { newValue in
+                        .onChange(of: descriptionInput) { _, newValue in
                             viewModel.updateDescriptionInput(newValue)
                             predictedCategory = ""
                         }

--- a/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
@@ -313,8 +313,8 @@ private struct TransactionEditor: View {
                 }
                 refreshPrediction()
             }
-            .onChange(of: desc) { _ in refreshPrediction() }
-            .onChange(of: amount) { _ in refreshPrediction() }
+            .onChange(of: desc) { refreshPrediction() }
+            .onChange(of: amount) { refreshPrediction() }
             .onDisappear {
                 predictionTask?.cancel()
                 predictionTask = nil


### PR DESCRIPTION
## Summary
- replace deprecated `onChange(of:perform:)` handlers with the new zero-parameter form when the value change result is unused
- adopt the two-parameter closure signature for `onChange` handlers that rely on the updated value to satisfy iOS 17 requirements

## Testing
- swift build *(fails: SwiftUI is unavailable in the Linux container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d161fbf26c832faca65056279456f7