### PR TITLE
Fix Swift warnings in analysis and prediction code

### DIFF
--- a/ios/HomeBudgetingApp/Domain/AnalysisCalculator.swift
+++ b/ios/HomeBudgetingApp/Domain/AnalysisCalculator.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func buildBudgetSpread(monthKey: String?, month: BudgetMonth?) -> AnalysisResult? {
-    guard let monthKey, let month else { return nil }
+    guard monthKey != nil, let month else { return nil }
     let totals = computeMonthTotals(month)
     guard !totals.groups.isEmpty else { return nil }
     let labels = totals.groups.map { $0.name }

--- a/ios/HomeBudgetingApp/Domain/PredictionEngine.swift
+++ b/ios/HomeBudgetingApp/Domain/PredictionEngine.swift
@@ -35,7 +35,7 @@ actor PredictionEngine {
     func learnCategory(desc: String, category: String?, amount: Double?) async {
         guard !desc.isEmpty, let category, !category.isEmpty else { return }
         let base = desc.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        var state = await repository.currentState()
+        let state = await repository.currentState()
         var exact = state.mapping.exact
         var tokenMap = state.mapping.tokens
         if let amount, amount.isFinite {
@@ -88,7 +88,7 @@ actor PredictionEngine {
     private func updateDescriptionMap(desc: String, category: String) async {
         let normalized = desc.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty else { return }
-        var state = await repository.currentState()
+        let state = await repository.currentState()
         var tokens = state.descMap.tokens
         var catBag = tokens[category] ?? [:]
         catBag[normalized, default: 0] += 1


### PR DESCRIPTION
## Summary
- avoid binding an unused month key when building budget spreads
- make repository state lookups immutable where the value is not mutated

## Testing
- npm install
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d16b72e608832fb813b8421b17da66