### PR TITLE
Fix calendar totals to use signed amounts

### DIFF
--- a/ios/HomeBudgetingApp/Domain/BudgetCalculations.swift
+++ b/ios/HomeBudgetingApp/Domain/BudgetCalculations.swift
@@ -220,8 +220,7 @@ func buildCalendar(monthKey: String?, month: BudgetMonth?, today: Date = Date())
     month?.transactions.forEach { tx in
         guard let date = parseDate(tx.date) else { return }
         let day = calendar.component(.day, from: date)
-        let amount = abs(tx.amount)
-        totalsByDay[day, default: 0] += amount
+        totalsByDay[day, default: 0] += tx.amount
         transactionsByDay[day, default: []].append(tx)
     }
     let daysInMonth = calendar.range(of: .day, in: .month, for: firstDay)?.count ?? 30

--- a/ios/HomeBudgetingApp/HomeBudgetingApp.swift
+++ b/ios/HomeBudgetingApp/HomeBudgetingApp.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Combine)
 import SwiftUI
 
 struct HomeBudgetingAppEntry: App {
@@ -10,3 +11,4 @@ struct HomeBudgetingAppEntry: App {
         }
     }
 }
+#endif

--- a/ios/HomeBudgetingApp/ViewModels/BudgetViewModel.swift
+++ b/ios/HomeBudgetingApp/ViewModels/BudgetViewModel.swift
@@ -1,3 +1,4 @@
+#if canImport(Combine) && !os(Linux)
 import Foundation
 import Combine
 import UniformTypeIdentifiers
@@ -931,3 +932,4 @@ private struct TransactionDraft {
     let amount: Double
     let category: String
 }
+#endif

--- a/ios/HomeBudgetingApp/Views/Analysis/AnalysisScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Analysis/AnalysisScreen.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Charts) && canImport(Combine)
 import SwiftUI
 import Charts
 
@@ -904,3 +905,4 @@ struct AnalysisScreen_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Budget/BudgetScreen.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Combine)
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -1024,4 +1025,5 @@ private struct PendingImport {
         }
     }
 }
+#endif
 

--- a/ios/HomeBudgetingApp/Views/Calendar/CalendarScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Calendar/CalendarScreen.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Combine)
 import SwiftUI
 
 struct CalendarScreen: View {
@@ -263,3 +264,4 @@ struct CalendarScreen_Previews: PreviewProvider {
             .environmentObject(BudgetViewModel())
     }
 }
+#endif

--- a/ios/HomeBudgetingApp/Views/Components/AppDialog.swift
+++ b/ios/HomeBudgetingApp/Views/Components/AppDialog.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Combine)
 import SwiftUI
 
 struct AppDialog: Identifiable {
@@ -79,3 +80,4 @@ extension View {
         }
     }
 }
+#endif

--- a/ios/HomeBudgetingApp/Views/Components/SignedDecimalKeyboardModifier.swift
+++ b/ios/HomeBudgetingApp/Views/Components/SignedDecimalKeyboardModifier.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Combine)
 import SwiftUI
 
 struct SignedDecimalKeyboardModifier: ViewModifier {
@@ -38,3 +39,4 @@ extension View {
         modifier(SignedDecimalKeyboardModifier(text: text))
     }
 }
+#endif

--- a/ios/HomeBudgetingApp/Views/HomeBudgetingRootView.swift
+++ b/ios/HomeBudgetingApp/Views/HomeBudgetingRootView.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Combine)
 import SwiftUI
 
 public struct HomeBudgetingRootView: View {
@@ -31,3 +32,4 @@ struct HomeBudgetingRootView_Previews: PreviewProvider {
             .environmentObject(BudgetViewModel())
     }
 }
+#endif

--- a/ios/HomeBudgetingApp/Views/Notes/NotesScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Notes/NotesScreen.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Combine)
 import SwiftUI
 
 struct NotesScreen: View {
@@ -108,3 +109,4 @@ struct NotesScreen_Previews: PreviewProvider {
             .environmentObject(BudgetViewModel())
     }
 }
+#endif

--- a/ios/HomeBudgetingApp/Views/Prediction/PredictionScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Prediction/PredictionScreen.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Combine)
 import SwiftUI
 
 struct PredictionScreen: View {
@@ -106,3 +107,4 @@ struct PredictionScreen_Previews: PreviewProvider {
             .environmentObject(BudgetViewModel())
     }
 }
+#endif

--- a/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Combine)
 import SwiftUI
 
 struct TransactionsScreen: View {
@@ -246,6 +247,7 @@ struct ScrollOffsetPreferenceKey: PreferenceKey {
         value = nextValue()
     }
 }
+#endif
 
 
 private struct TransactionEditor: View {

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -19,6 +19,11 @@ let package = Package(
             resources: [
                 .process("Resources")
             ]
+        ),
+        .testTarget(
+            name: "HomeBudgetingAppTests",
+            dependencies: ["HomeBudgetingApp"],
+            path: "Tests/HomeBudgetingAppTests"
         )
     ]
 )

--- a/ios/Tests/HomeBudgetingAppTests/CalendarCalculationsTests.swift
+++ b/ios/Tests/HomeBudgetingAppTests/CalendarCalculationsTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import HomeBudgetingApp
+
+final class CalendarCalculationsTests: XCTestCase {
+    func testCalendarTotalsUseSignedTransactions() throws {
+        let month = BudgetMonth(
+            incomes: [],
+            transactions: [
+                BudgetTransaction(id: "1", date: "20-09-2025", desc: "Groceries", amount: 40.0, category: "Food"),
+                BudgetTransaction(id: "2", date: "20-09-2025", desc: "Fuel", amount: 27.75, category: "Travel"),
+                BudgetTransaction(id: "3", date: "20-09-2025", desc: "Temu refund", amount: -7.44, category: "Shopping")
+            ],
+            categories: [:]
+        )
+
+        let calendarMonth = buildCalendar(monthKey: "2025-09", month: month, today: Date(timeIntervalSince1970: 0))
+
+        let calendarDay = calendarMonth.weeks
+            .flatMap { $0 }
+            .first { $0.dayOfMonth == 20 }
+
+        XCTAssertNotNil(calendarDay)
+        XCTAssertEqual(calendarDay?.total, 60.31, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
- ensure calendar totals sum signed transaction amounts so refunds reduce daily spend
- add a regression test covering a day that mixes purchases and a refund
- wrap SwiftUI- and Combine-dependent sources in availability checks so the SPM tests can build when those frameworks are absent

## Testing
- npm test
- swift test *(fails: Apple SwiftUI/Combine frameworks unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cd77cb08832fa84251ec1f9d5e14