### PR TITLE
Replace transactions filter text with icon

### DIFF
--- a/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
+++ b/ios/HomeBudgetingApp/Views/Transactions/TransactionsScreen.swift
@@ -93,19 +93,18 @@ struct TransactionsScreen: View {
 
 
     private var categoryFilter: some View {
-        Picker(
-            selection: categoryBinding,
-            label: Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
-                .labelStyle(.iconOnly)
-        ) {
-            Text("All").tag("")
-            ForEach(transactionsState.availableCategories, id: \.self) { category in
-                Text(category).tag(category)
+        Menu {
+            Picker("Filter", selection: categoryBinding) {
+                Text("All").tag("")
+                ForEach(transactionsState.availableCategories, id: \.self) { category in
+                    Text(category).tag(category)
+                }
             }
+        } label: {
+            Image(systemName: "line.3.horizontal.decrease.circle")
         }
-        .pickerStyle(.menu)
+        .accessibilityLabel("Filter transactions")
         .controlSize(.small)
-        .frame(maxWidth: 80)
     }
     
     private var addButton: some View {


### PR DESCRIPTION
## Summary
- update the transactions toolbar filter to show a filter icon instead of the selected text
- keep the existing category picker options while using an accessible icon button entry point

## Testing
- not run (Xcode tooling is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d7a0c0b858832fbd789562630df801